### PR TITLE
Fix DataTable column parsing

### DIFF
--- a/im_output/Expense Analyzer Dashboard_IM.json
+++ b/im_output/Expense Analyzer Dashboard_IM.json
@@ -1,7 +1,6989 @@
 {
-  "DataTables": [],
-  "Visualizations": [],
-  "Filters": [],
+  "DataTables": [
+    {
+      "Id": "118",
+      "Name": "SpotfireExpenseAnalyzer",
+      "DataSource": "",
+      "Transformations": [],
+      "Columns": [
+        {
+          "Name": "Report Creation Date",
+          "DataType": "Date",
+          "Expression": ""
+        },
+        {
+          "Name": "Expenditure Date",
+          "DataType": "Date",
+          "Expression": ""
+        },
+        {
+          "Name": "Invoice Number",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Employee Id",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Type",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Department",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Line Amount",
+          "DataType": "Currency",
+          "Expression": ""
+        },
+        {
+          "Name": "Employee Status",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Year of Employment",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Days to File Expense",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Timliness",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Experience Bucket",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Month",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Average Expense Type Cost",
+          "DataType": "Currency",
+          "Expression": ""
+        }
+      ],
+      "Relationships": []
+    }
+  ],
+  "Visualizations": [
+    {
+      "Id": "1557",
+      "Type": "BarChart",
+      "DataTable": [
+        {
+          "Id": "1586",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "35ded1c2-3825-439c-a5a0-779beaab6681",
+            "DataTable": "118",
+            "UseActiveFiltering": "false",
+            "ActiveFiltering": "0",
+            "Filterings": [
+              {
+                "Id": "1589",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "e8842e7a-1806-4478-b574-8c125f1f05fd",
+                  "Items": [
+                    {
+                      "Id": "1594",
+                      "Type": "VisualizationFilteringCollection+VisualizationFilteringReference",
+                      "Fields": {
+                        "DocumentNodeId": "802f54e9-801a-412c-8526-0abf2fd4dc5a",
+                        "Reference": "138"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "1596",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "1964f068-56f2-4601-a236-f914deabde03",
+                  "Items": [
+                    {
+                      "Id": "1601",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "67f582a8-ff9f-4fb5-9fec-90bdb382c32e",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "1605",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "cb59c481-4ece-4868-8219-9eccd5cc973f",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "1607",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "2fd7ccde-1989-47aa-b3d2-75034514e5fd",
+                        "ManualDisplayName": "450",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "18",
+            "FilteringsLegendItem": [
+              {
+                "Id": "1609",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "4dbe4109-958e-45db-9447-355e5b0c155a",
+                  "Visible": "true",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "1613",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "2ff0a278-f541-4439-ba24-ed2139ff52f4",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "1616",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "1f37a900-c596-4798-a2cc-ddc911c78f64",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "1620",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "03fc2246-a16a-4893-8a69-aa0de7f68c97",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyBehavior": "ShowEmpty",
+            "LimitingMarkingsEmptyMessage": "Mark items to view details here.",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "1626",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "0c160440-8314-4c1b-b326-8754f8660896",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "1637",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "ef21080b-c863-4bd5-8ae4-998825f74e8a",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "1640",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "8af31513-fc74-413a-b4f2-c9d3440dd5ae",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "1643",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "76edca7c-3731-483f-9908-6e4e9cc422e3",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "1654",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "c04b7a7a-d690-415f-b5cb-46c0b5f0c723",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "1665",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "2333b91d-b4a8-4cee-91a8-c0572593191c",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "1667",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "18fadb6b-eee6-4cdb-9e1d-0b7f59cf6067",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "1678",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "0c4128c3-ea1c-47fa-a94e-5846a380c180",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "1689",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "5d84433c-af8f-46a2-84c0-7dd101d6b4e5",
+              "Visible": "false",
+              "Dock": [
+                {
+                  "Id": "1692",
+                  "Type": "LegendDock",
+                  "Fields": {
+                    "alignment": "right"
+                  },
+                  "Children": []
+                }
+              ],
+              "Width": "150",
+              "Items": [
+                {
+                  "Id": "1695",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "c7129f43-c331-4571-b8f4-0f3c5db2567c",
+                    "Items": [
+                      {
+                        "Id": "1700",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "0a98cd6d-021b-4396-8ae7-9a3435a382cf",
+                          "Item": "1702"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1703",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "b8010ff9-01ae-4534-b125-c1cb9510a574",
+                          "Item": "1705"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1706",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "9f053509-38fe-4e12-bda4-84f69b39981d",
+                          "Item": "1609"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1708",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "6551247f-14df-452a-8f41-0bd4a9f23dbd",
+                          "Item": "1613"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1710",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "9e6f85ab-62a7-4c0b-8101-5033917db5bb",
+                          "Item": "1616"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1712",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "4f000200-3783-4316-92e1-fb759eb0d3fa",
+                          "Item": "1714"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1715",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "d5f86eb3-df46-494e-8ba6-70ed493c59af",
+                          "Item": "1717"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1718",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "b1b7e705-c0d4-452f-9340-4b423678eb93",
+                          "Item": "1720"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1721",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "de05f312-f431-4fd9-8798-81de51065a48",
+                          "Item": "1723"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "1724",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "5b931a03-89c2-4dd7-a235-0bed9a43b991",
+                          "Item": "1726"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    },
+    {
+      "Id": "2664",
+      "Type": "LineChart",
+      "DataTable": [
+        {
+          "Id": "2689",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "d1a1f2d8-c8c7-4ab5-8094-04a1dfcda4d0",
+            "DataTable": "118",
+            "UseActiveFiltering": "false",
+            "ActiveFiltering": "0",
+            "Filterings": [
+              {
+                "Id": "2691",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "e5ec0c43-82d0-4dde-bed4-ef251bc6b254",
+                  "Items": [
+                    {
+                      "Id": "2694",
+                      "Type": "VisualizationFilteringCollection+VisualizationFilteringReference",
+                      "Fields": {
+                        "DocumentNodeId": "15e2a05f-3ab5-43ef-b7c2-a6147b895550",
+                        "Reference": "122"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "2696",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "e5bb9bca-9813-48c3-9806-f15218ae6bcb",
+                  "Items": [
+                    {
+                      "Id": "2699",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "e8600356-f239-44f5-80d1-9f9d491833cb",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "2701",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "acbba8f8-0724-4bfb-978b-576873ea61f8",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "2703",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "5f845425-1fde-44d7-be02-bb957d404af3",
+                        "ManualDisplayName": "450",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "18",
+            "FilteringsLegendItem": [
+              {
+                "Id": "2705",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "9423e9c1-5aba-48b8-a94c-21f6487fa8bd",
+                  "Visible": "true",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "2707",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "bfafab92-7927-4cf7-b7fe-ba0dde5d5ed7",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "2709",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "1b13c277-e652-42c5-8b85-c0a50749240e",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "2711",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "2120b523-bcbf-4ea2-a249-63b47fa4451f",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyBehavior": "ShowEmpty",
+            "LimitingMarkingsEmptyMessage": "1625",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "2714",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "e5593d7c-708b-4088-9bfc-e4d012db0f85",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "2725",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "39e636f7-5f12-4396-9fcb-1d2fc96279fc",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "2727",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "1b48c640-a673-4187-b2a4-9e991d7b5731",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "2729",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "bcc83970-ea1f-4b6b-b128-28aadd76f0bf",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "2740",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "3997f5d4-3fc0-4b01-8265-dd8a3d1bf9b3",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "2751",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "f185c7fa-a1fa-4dfc-939b-b50e0e621118",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "2753",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "282a758e-dcd0-4520-9263-95a7733ad5a7",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "2764",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "d1ef612a-7399-4dd7-851e-a64e6f15cab8",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "2775",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "80889c69-f724-47dc-9c83-09f2f92c2510",
+              "Visible": "false",
+              "Dock": "1692",
+              "Width": "150",
+              "Items": [
+                {
+                  "Id": "2777",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "bce12b52-cec2-4b9d-b796-3ff2ddce9a68",
+                    "Items": [
+                      {
+                        "Id": "2780",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "c97b0f63-129b-4fa7-9082-57be8a49e7e3",
+                          "Item": "2782"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2783",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "e63528f0-165c-4178-9556-6be46d6c4173",
+                          "Item": "2785"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2786",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "eb54c447-ca5b-46e2-a5f9-13965dfe43f6",
+                          "Item": "2705"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2788",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "1b994092-4922-46d2-9b78-ab7b55854a31",
+                          "Item": "2707"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2790",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "853cfca4-d443-4636-8974-4f860f2db000",
+                          "Item": "2709"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2792",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "e608a163-97b5-48df-ad89-19d96b924997",
+                          "Item": "2794"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2795",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "2e028818-7663-4621-8d72-15aae53a2bae",
+                          "Item": "2797"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2798",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "06a23745-586c-4671-895b-e6ed44e04687",
+                          "Item": "2800"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2801",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "fe676d53-e87d-407a-acf8-5fcb83ee4ba8",
+                          "Item": "2803"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2804",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "525d92c7-e8d6-44d9-b959-1210dbd3666b",
+                          "Item": "2806"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "2807",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "3793dfbe-7f73-442e-a283-65bd585fb7bb",
+                          "Item": "2809"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    },
+    {
+      "Id": "5278",
+      "Type": "BarChart",
+      "DataTable": [
+        {
+          "Id": "5299",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "bdd1b6c7-c5bb-4d84-b7b3-0d9687c0fad5",
+            "DataTable": "118",
+            "UseActiveFiltering": "false",
+            "ActiveFiltering": "0",
+            "Filterings": [
+              {
+                "Id": "5301",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "b325c3cb-100f-46c6-a0a2-da4f47abf2ef",
+                  "Items": [
+                    {
+                      "Id": "5304",
+                      "Type": "VisualizationFilteringCollection+VisualizationFilteringReference",
+                      "Fields": {
+                        "DocumentNodeId": "78302c61-8b7e-4f09-8cc2-646326e7d034",
+                        "Reference": "122"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "5306",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "a16a7a47-1a98-4e54-9bc3-5811b4f1f4c0",
+                  "Items": [
+                    {
+                      "Id": "5309",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "f7904807-b0c1-4a03-bce6-b9bd9f594751",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "5311",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "70919bb1-c9fb-468f-ba6a-7977c912a9a7",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "5313",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "16e84871-ddc5-43c2-80f9-0a7370c34486",
+                        "ManualDisplayName": "450",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "18",
+            "FilteringsLegendItem": [
+              {
+                "Id": "5315",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "dd34b2cb-37a8-435f-ac42-4ef0cb91a70c",
+                  "Visible": "true",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "5317",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "3aa7aa09-1603-4a3d-b07d-f86841a1e3fe",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "5319",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "dd66fd79-0187-4e6d-9eb5-e5e14afccb85",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "5321",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "6d95c42b-721b-41fe-bb7c-e73f194a266d",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyBehavior": "ShowEmpty",
+            "LimitingMarkingsEmptyMessage": "1625",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "5324",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "09b258a7-8c47-4249-82ed-ef49142e3ef3",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "5335",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "01c17141-7d5b-4eaa-a148-ad2f6a76dbeb",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "5337",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "4817f8e4-3884-49a9-a159-0a744c8273ba",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "5339",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "32a5dbfc-2ca6-48df-a54e-5bfd3daeb09a",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "5350",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "64602c1b-6a3d-4dae-92d0-344fbb7e54e0",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "5361",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "c7b84000-dade-4289-afd2-96abb072e427",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "5363",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "e561f6f2-d4b4-4e10-9b08-b3e4cc5dc637",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "5374",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "ee216f84-c12b-4331-b82c-3fd9c77c5232",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "5385",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "36241513-dac3-437c-9c37-7980af839a68",
+              "Visible": "false",
+              "Dock": "1692",
+              "Width": "150",
+              "Items": [
+                {
+                  "Id": "5387",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "8a5912cb-5d8b-47f1-b7ee-1d46e7b86442",
+                    "Items": [
+                      {
+                        "Id": "5390",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "08168e20-305e-4e6f-8795-1d8bef4469ee",
+                          "Item": "5392"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5393",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "17b3ef2f-4510-4ab2-b475-551b74883af7",
+                          "Item": "5395"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5396",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "1b8cf334-c90d-4966-864c-adfaeed80f75",
+                          "Item": "5315"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5398",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "9cfb1d27-1d14-47d5-b39f-4dd8a22e6c7e",
+                          "Item": "5317"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5400",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "e37abb50-41e3-4fbb-b240-38a9de4b171a",
+                          "Item": "5319"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5402",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "14c229db-a2b2-49c4-be81-436f899d0964",
+                          "Item": "5404"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5405",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "9b121f63-e0aa-4d70-a3bb-43827d41f42e",
+                          "Item": "5407"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5408",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "73401132-4a9f-49db-8de1-63bcfa6d6cca",
+                          "Item": "5410"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5411",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "6bd1fa55-2e0d-496a-b03a-2c6f7a245c9c",
+                          "Item": "5413"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "5414",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "30fa8fbf-72b7-4e2c-b745-f36a313914ae",
+                          "Item": "5416"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    },
+    {
+      "Id": "6087",
+      "Type": "BarChart",
+      "DataTable": [
+        {
+          "Id": "6108",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "bab27e2f-30a4-4aaf-845e-48cbc4987d69",
+            "DataTable": "118",
+            "UseActiveFiltering": "false",
+            "ActiveFiltering": "0",
+            "Filterings": [
+              {
+                "Id": "6110",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "9b92916e-b183-4a91-ad40-e898ddb2de2c",
+                  "Items": [
+                    {
+                      "Id": "6113",
+                      "Type": "VisualizationFilteringCollection+VisualizationFilteringReference",
+                      "Fields": {
+                        "DocumentNodeId": "6dd2b5d1-f2bd-4bfa-a37e-6998f0b98055",
+                        "Reference": "130"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "6115",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "8a8540a6-e974-4e3c-ad5f-37304642c249",
+                  "Items": [
+                    {
+                      "Id": "6118",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "2c1f189b-6eb0-4988-b839-5bba703b1bf4",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "6120",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "02eafcfa-2cff-4e42-96a7-a5e48583e21a",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "6122",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "7b6078c7-6461-4f73-a323-991b5382e603",
+                        "ManualDisplayName": "450",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "18",
+            "FilteringsLegendItem": [
+              {
+                "Id": "6124",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "10ce05d4-8ae5-4e19-b663-c69442424f90",
+                  "Visible": "true",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "6126",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "8e942771-463d-48bf-8924-b0c9aaeee7cd",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "6128",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "cb06e536-24a5-4a44-854f-e337573c55e5",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "6130",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "be44049f-22fb-4bff-87dd-df9744c814b9",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyBehavior": "ShowEmpty",
+            "LimitingMarkingsEmptyMessage": "1625",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "6133",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "fc60dab9-e7af-428a-9099-9f15020f2519",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "6144",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "6cd210ba-823b-4095-bbee-946541aa74d8",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "6146",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "3b90fa3e-eec0-4e20-a14e-5d457805d823",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "6148",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "528c86da-6bda-4604-859a-51260dd54e68",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "6159",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "0ec92ff4-3376-45a3-b03b-e7fe08606c5f",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "6170",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "b4f4d8d5-549d-416f-a9d6-654ec460fa68",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "6172",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "037a8dd7-e4d7-42d6-b0c1-d68e903e886c",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "6183",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "a983b782-adaf-4b6b-9df8-99525230524e",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "6194",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "cc589a1c-7031-40b5-92f6-89d1c8a9d628",
+              "Visible": "false",
+              "Dock": "1692",
+              "Width": "150",
+              "Items": [
+                {
+                  "Id": "6196",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "855510ca-ddfc-4a9e-9d0d-8f09c7ca2967",
+                    "Items": [
+                      {
+                        "Id": "6199",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "59d40b82-f261-4f7b-a171-4cb9c5808a91",
+                          "Item": "6201"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6202",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "c39b5310-6172-41d3-b8ca-c4c739b83d83",
+                          "Item": "6204"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6205",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "40a4209c-8b59-45df-8a6a-4c7f267f9028",
+                          "Item": "6124"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6207",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "04af69bd-4e85-4b2d-a79c-a3fc1e75d400",
+                          "Item": "6126"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6209",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "40777a6b-7a3b-4020-8f55-707fab72e74a",
+                          "Item": "6128"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6211",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "78dc88b8-149e-49c0-9c7d-adddadbda049",
+                          "Item": "6213"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6214",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "50e336d8-0ef5-4e93-a93e-845ff458290a",
+                          "Item": "6216"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6217",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "b04b6c84-ddf3-43b8-acf2-08479ee19a65",
+                          "Item": "6219"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6220",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "445c4b03-1b84-44a4-bfa1-c24407a1a6c7",
+                          "Item": "6222"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "6223",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "cb2a1dca-d40f-4dd7-987c-e45f3553ea45",
+                          "Item": "6225"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    },
+    {
+      "Id": "6896",
+      "Type": "LineChart",
+      "DataTable": [
+        {
+          "Id": "6917",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "aa348192-11ee-491e-9823-e0a89e5855e1",
+            "DataTable": "118",
+            "UseActiveFiltering": "false",
+            "ActiveFiltering": "0",
+            "Filterings": [
+              {
+                "Id": "6919",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "84a098a7-c3f4-4f53-a265-afbb00bc6a32",
+                  "Items": [
+                    {
+                      "Id": "6922",
+                      "Type": "VisualizationFilteringCollection+VisualizationFilteringReference",
+                      "Fields": {
+                        "DocumentNodeId": "dee095ec-d007-4ada-a7d3-dd3302a9cf79",
+                        "Reference": "138"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "6924",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "45a4499b-d82b-48ae-8dbc-14f53d707fa8",
+                  "Items": [
+                    {
+                      "Id": "6927",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "3c701e55-4a67-4883-8e2b-1442c21d75af",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "6929",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "c850164b-269b-483f-857d-ccae6b1bf917",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "6931",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "3d8e7120-400d-4e3a-b2e6-a2b50eff41f0",
+                        "ManualDisplayName": "450",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "18",
+            "FilteringsLegendItem": [
+              {
+                "Id": "6933",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "59fee2e4-4f37-4607-b6f8-9585b481efcc",
+                  "Visible": "true",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "6935",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "b214a4b7-6f01-4a81-a196-88c223d71918",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "6937",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "13079f8e-32f9-47fb-942c-41f59219af85",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "6939",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "5f1d1bb6-8efe-456b-b2d7-2f46befc2922",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyBehavior": "ShowEmpty",
+            "LimitingMarkingsEmptyMessage": "1625",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "6942",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "7a991746-1bb5-4ce1-9953-125254cb88cb",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "6953",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "61214fad-20e9-4b74-94e5-6d353cf7cb61",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "6955",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "06d3f322-f7db-4812-ac8e-2e63dff2b91d",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "6957",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "e0c620df-4de8-422e-9915-e080b33842c4",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "6968",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "ca651b17-3053-41fa-b54b-a70a25a63d30",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "6979",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "cfea918e-e95f-4095-9271-b82a8ac50b9d",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "6981",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "9b3457cb-9e32-44c7-83f7-0993a3aa5443",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "6992",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "2f05158b-ba2c-427e-92b5-fe33a5b1e654",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "7003",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "5af4bc5c-b456-494d-ab9f-28f88bca6dbe",
+              "Visible": "false",
+              "Dock": "1692",
+              "Width": "150",
+              "Items": [
+                {
+                  "Id": "7005",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "f1b76586-a6db-4eb8-9545-bcd0ea69122f",
+                    "Items": [
+                      {
+                        "Id": "7008",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "5f67242c-d9f8-489c-8804-6805e3fa78dc",
+                          "Item": "7010"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7011",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "345c52d8-cc51-488b-bc51-ba6d2526bf25",
+                          "Item": "7013"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7014",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "36ba82d9-2e9a-4f23-912e-6ad0cb41ae32",
+                          "Item": "6933"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7016",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "2c22c757-cca9-46d1-a8c0-75fc9459b033",
+                          "Item": "6935"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7018",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "22b0bfe6-aa3b-465a-8084-461afe0a7fc7",
+                          "Item": "6937"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7020",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "d5cb0f2a-be1a-4d60-b50d-04f1e9b60728",
+                          "Item": "7022"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7023",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "64a2443f-6545-469b-9132-9a0bb2303ebe",
+                          "Item": "7025"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7026",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "8d9052bd-3151-4332-9f24-deb932504845",
+                          "Item": "7028"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7029",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "49de0986-2c20-4c82-b5a9-9bd13af1cb39",
+                          "Item": "7031"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7032",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "4a5c1e0b-9a61-4609-9384-541bd28d1f65",
+                          "Item": "7034"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7035",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "24d210cb-d6f2-4a20-810d-1ecc63d61570",
+                          "Item": "7037"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    },
+    {
+      "Id": "7692",
+      "Type": "LineChart",
+      "DataTable": [
+        {
+          "Id": "7713",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "49ecbc10-84db-47d3-aa13-43f3eeb41a35",
+            "DataTable": "118",
+            "UseActiveFiltering": "false",
+            "ActiveFiltering": "0",
+            "Filterings": [
+              {
+                "Id": "7715",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "3aac2e52-942e-4a0a-acb0-5e519bce6997",
+                  "Items": [
+                    {
+                      "Id": "7718",
+                      "Type": "VisualizationFilteringCollection+VisualizationFilteringReference",
+                      "Fields": {
+                        "DocumentNodeId": "ea592548-f7b3-4d2b-924a-7c279cee1aa1",
+                        "Reference": "130"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "7720",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "5c66a36f-9837-40fe-a779-751b3ecf82b5",
+                  "Items": [
+                    {
+                      "Id": "7723",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "a3054511-e67f-4281-a9e4-d1e08f679de2",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "7725",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "9dabfd6d-3a5d-4c2f-b195-58148d6f8ef9",
+                        "ManualDisplayName": "450",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "7727",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "103b46fd-6a94-44e8-a919-fa62ed341739",
+                        "ManualDisplayName": "450",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "18",
+            "FilteringsLegendItem": [
+              {
+                "Id": "7729",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "40ad7d11-99c6-4d07-be9f-cf2115b68566",
+                  "Visible": "true",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "7731",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "a7a15cd7-6522-46bc-9f2f-fec0bd41ce87",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "7733",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "55015ae8-10c8-4670-a6b0-7b881d83da97",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "7735",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "3de3833e-1a66-43b8-b466-8f8470e84cdd",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyBehavior": "ShowEmpty",
+            "LimitingMarkingsEmptyMessage": "1625",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "7738",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "d79ddf01-56a1-430c-adad-dee0df598105",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "7749",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "65d6ec3c-1324-41ea-99ca-88c08d0062d8",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "7751",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "12b30779-b372-4d8f-ad5b-1c726747eac4",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "7753",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "51d95baa-78f0-48d9-874a-e6ac9fd7274a",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "7764",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "2d14258a-75cd-496a-a17e-7f9151649af8",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "7775",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "c1cc68e9-2109-4971-bf39-daee957373e9",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "7777",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "0681978a-925a-4d0e-ba88-c1a63cf298f8",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "7788",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "b0722039-9224-4af6-8cee-ff7a02f5b9fa",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "7799",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "1dd54df5-694b-4c65-a519-7d35946d6ba1",
+              "Visible": "false",
+              "Dock": "1692",
+              "Width": "150",
+              "Items": [
+                {
+                  "Id": "7801",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "3f3a2931-d1f9-4c7e-8ef9-72cf2018e42d",
+                    "Items": [
+                      {
+                        "Id": "7804",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "8b3b176c-8760-4ee6-a015-4338952487bb",
+                          "Item": "7806"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7807",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "19039d02-27b3-4a9b-b5b1-6daadb743194",
+                          "Item": "7809"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7810",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "0492f667-11e1-4c90-9321-60c5ee223ceb",
+                          "Item": "7729"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7812",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "f48ae3ca-169e-4971-9bb2-e5907ff9a257",
+                          "Item": "7731"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7814",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "d62d4453-a43b-45fc-8a9b-4cd9749982f6",
+                          "Item": "7733"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7816",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "87a4a309-13c4-4339-8e54-923fccd7b14b",
+                          "Item": "7818"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7819",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "cb03e111-212c-456b-bf4b-17ab36b0fb1c",
+                          "Item": "7821"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7822",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "cfb0d8e4-15c2-48ce-a53c-c7463b7ab5ea",
+                          "Item": "7824"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7825",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "d7a579ae-14c6-4917-bc0b-702e79e9fd3b",
+                          "Item": "7827"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7828",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "377feaf1-fdc0-45be-ada0-807e873b0683",
+                          "Item": "7830"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "7831",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "8b154f20-4a0a-4a9d-8afa-f7e859a3bcbb",
+                          "Item": "7833"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    }
+  ],
+  "Filters": [
+    {
+      "Id": "1241",
+      "Type": "FilteringScheme",
+      "Fields": {
+        "DocumentNodeId": "790b1904-fd66-44d7-bc7d-ddb15e0cc45c",
+        "Items": [
+          {
+            "Id": "1319",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "a243a133-fc3e-44d5-80c3-8a55257cc5db",
+              "Items": [
+                {
+                  "Id": "1266",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9ba6d1e7-f501-4b16-b6db-53669be8b788",
+                    "FilterBase": [
+                      {
+                        "Id": "8652",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "524be449-ff87-471d-ab14-eeccfb5c89cf",
+                          "DataColumn": [
+                            {
+                              "Id": "8657",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "174",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8652",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1270",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4edaa3d2-a1bc-45b8-b4fb-f1a3a8726b67",
+                    "FilterBase": [
+                      {
+                        "Id": "8668",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "47f6bdd9-08b1-4fe6-9dce-e0450024b25c",
+                          "DataColumn": [
+                            {
+                              "Id": "8670",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "215",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8668",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1274",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ee453da9-5a4b-446c-8fc1-fdf032016b5e",
+                    "FilterBase": [
+                      {
+                        "Id": "8674",
+                        "Type": "TextFilter",
+                        "Fields": {
+                          "DocumentNodeId": "841fe09b-48ea-4ebe-8b1f-92fcd43cc34a",
+                          "DataColumn": [
+                            {
+                              "Id": "8677",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "229",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": "450"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1278",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1af145c4-47bd-4c6a-8dd1-c9ff9551bcbe",
+                    "FilterBase": [
+                      {
+                        "Id": "8679",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "e6520166-3e18-46eb-ab2a-c73eda9f3831",
+                          "DataColumn": [
+                            {
+                              "Id": "8681",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "245",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8679",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1282",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "549c8e60-8095-4501-a117-e2432494544f",
+                    "FilterBase": [
+                      {
+                        "Id": "8685",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "450",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "8687",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "d61cef4f-7454-4c2c-8920-d6deafa8f334",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "ea82707b-3a7b-45a2-9694-66939badfbea",
+                          "DataColumn": [
+                            {
+                              "Id": "8692",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "261",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1286",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a650f54f-80d6-4d87-b8a6-0059c5efb369",
+                    "FilterBase": [
+                      {
+                        "Id": "8694",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "false",
+                          "SearchExpression": "finance",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "8696",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "f94c75be-83f1-49b7-9841-7439b56a8438",
+                                "SelectedValueIndexes": [
+                                  {
+                                    "Id": "8698",
+                                    "Type": "IndexSet",
+                                    "Fields": {
+                                      "Capacity": "16",
+                                      "Count": "3",
+                                      "FullBlockCount": "0",
+                                      "IsReadOnly": "true",
+                                      "First": "4",
+                                      "Last": "9",
+                                      "BlockCount": "1",
+                                      "Blocks": [
+                                        {
+                                          "Id": "8702",
+                                          "Type": "IndexSet+Block",
+                                          "Fields": {
+                                            "Count": "3",
+                                            "Data": []
+                                          },
+                                          "Children": []
+                                        }
+                                      ]
+                                    },
+                                    "Children": []
+                                  }
+                                ],
+                                "FilterTableSelectionColumn": "1090",
+                                "ProducerKey": "1168"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "bc9bdca7-28e9-49bc-92df-81e6cab80e3b",
+                          "DataColumn": [
+                            {
+                              "Id": "8706",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "279",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1290",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "88555e25-a32f-4e26-8108-4b6009c7139a",
+                    "FilterBase": [
+                      {
+                        "Id": "8708",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "568cb74c-8e8d-47b5-add1-a28ccbea25b2",
+                          "DataColumn": [
+                            {
+                              "Id": "8710",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "297",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8708",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1294",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "488ad0d4-9d55-47f9-99b5-0c471cd0e3a5",
+                    "FilterBase": [
+                      {
+                        "Id": "8714",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "64c22c10-595a-48e5-97eb-d2c407347692",
+                          "DataColumn": [
+                            {
+                              "Id": "8717",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "317",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "8718",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1298",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0f96a5ca-4856-4dcd-96d7-4524085ed2b2",
+                    "FilterBase": [
+                      {
+                        "Id": "8722",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "55ee2af7-6e10-47d3-92c4-ea04a1aac9ac",
+                          "DataColumn": [
+                            {
+                              "Id": "8724",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "331",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "8725",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1302",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0ed7ffce-e0b0-4b21-b2df-4f4b10954f18",
+                    "FilterBase": [
+                      {
+                        "Id": "8728",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "5ac35c7c-33fd-4465-b82b-2c04634c044a",
+                          "DataColumn": [
+                            {
+                              "Id": "8730",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "345",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8728",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1306",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1519afe2-a4c5-4bf1-b634-3020022bf57f",
+                    "FilterBase": [
+                      {
+                        "Id": "8734",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a00f0502-1edd-4fe6-beb9-22f23975b4ae",
+                          "DataColumn": [
+                            {
+                              "Id": "8736",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "359",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "8737",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1310",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3c9f47bd-f711-4da9-8a91-78d70d8a24cd",
+                    "FilterBase": [
+                      {
+                        "Id": "8740",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "abfd1dfc-6010-4b7a-b9c2-4788476d2280",
+                          "DataColumn": [
+                            {
+                              "Id": "8742",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "373",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "8743",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1314",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d10c172a-e722-43b5-b33a-ff1508dca41e",
+                    "FilterBase": [
+                      {
+                        "Id": "8746",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f72fda7b-71df-4a2e-83c9-0843dcd123b2",
+                          "DataColumn": [
+                            {
+                              "Id": "8748",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "391",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "8749",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "1318",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0b2b0c5e-c642-46eb-9572-774b021716e4",
+                    "FilterBase": [
+                      {
+                        "Id": "8752",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "cc5438b0-6a00-406e-8b59-f6f8b98b48a8",
+                          "DataColumn": [
+                            {
+                              "Id": "8754",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "405",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8752",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "119",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "5c949773-8db8-4f22-bed0-fe866c1a2156",
+                    "DataTable": "118",
+                    "FilterCollection": "1319"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "118",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "8760",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "97e81e09-838d-46c4-becc-e88e67940809",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ],
+        "DataSelection": "109",
+        "AutoConfigureFilterCollections": "true"
+      },
+      "Children": []
+    },
+    {
+      "Id": "1266",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9ba6d1e7-f501-4b16-b6db-53669be8b788",
+        "FilterBase": [
+          {
+            "Id": "8652",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "524be449-ff87-471d-ab14-eeccfb5c89cf",
+              "DataColumn": [
+                {
+                  "Id": "8657",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "174",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8652",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1270",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4edaa3d2-a1bc-45b8-b4fb-f1a3a8726b67",
+        "FilterBase": [
+          {
+            "Id": "8668",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "47f6bdd9-08b1-4fe6-9dce-e0450024b25c",
+              "DataColumn": [
+                {
+                  "Id": "8670",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "215",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8668",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1274",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ee453da9-5a4b-446c-8fc1-fdf032016b5e",
+        "FilterBase": [
+          {
+            "Id": "8674",
+            "Type": "TextFilter",
+            "Fields": {
+              "DocumentNodeId": "841fe09b-48ea-4ebe-8b1f-92fcd43cc34a",
+              "DataColumn": [
+                {
+                  "Id": "8677",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "229",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": "450"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1278",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1af145c4-47bd-4c6a-8dd1-c9ff9551bcbe",
+        "FilterBase": [
+          {
+            "Id": "8679",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "e6520166-3e18-46eb-ab2a-c73eda9f3831",
+              "DataColumn": [
+                {
+                  "Id": "8681",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "245",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8679",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1282",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "549c8e60-8095-4501-a117-e2432494544f",
+        "FilterBase": [
+          {
+            "Id": "8685",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "true",
+              "SearchExpression": "450",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "8687",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "d61cef4f-7454-4c2c-8920-d6deafa8f334",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "ea82707b-3a7b-45a2-9694-66939badfbea",
+              "DataColumn": [
+                {
+                  "Id": "8692",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "261",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1286",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a650f54f-80d6-4d87-b8a6-0059c5efb369",
+        "FilterBase": [
+          {
+            "Id": "8694",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "false",
+              "SearchExpression": "finance",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "8696",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "f94c75be-83f1-49b7-9841-7439b56a8438",
+                    "SelectedValueIndexes": [
+                      {
+                        "Id": "8698",
+                        "Type": "IndexSet",
+                        "Fields": {
+                          "Capacity": "16",
+                          "Count": "3",
+                          "FullBlockCount": "0",
+                          "IsReadOnly": "true",
+                          "First": "4",
+                          "Last": "9",
+                          "BlockCount": "1",
+                          "Blocks": [
+                            {
+                              "Id": "8702",
+                              "Type": "IndexSet+Block",
+                              "Fields": {
+                                "Count": "3",
+                                "Data": []
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ],
+                    "FilterTableSelectionColumn": "1090",
+                    "ProducerKey": "1168"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "bc9bdca7-28e9-49bc-92df-81e6cab80e3b",
+              "DataColumn": [
+                {
+                  "Id": "8706",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "279",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1290",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "88555e25-a32f-4e26-8108-4b6009c7139a",
+        "FilterBase": [
+          {
+            "Id": "8708",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "568cb74c-8e8d-47b5-add1-a28ccbea25b2",
+              "DataColumn": [
+                {
+                  "Id": "8710",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "297",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8708",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1294",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "488ad0d4-9d55-47f9-99b5-0c471cd0e3a5",
+        "FilterBase": [
+          {
+            "Id": "8714",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "64c22c10-595a-48e5-97eb-d2c407347692",
+              "DataColumn": [
+                {
+                  "Id": "8717",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "317",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "8718",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1298",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0f96a5ca-4856-4dcd-96d7-4524085ed2b2",
+        "FilterBase": [
+          {
+            "Id": "8722",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "55ee2af7-6e10-47d3-92c4-ea04a1aac9ac",
+              "DataColumn": [
+                {
+                  "Id": "8724",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "331",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "8725",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1302",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0ed7ffce-e0b0-4b21-b2df-4f4b10954f18",
+        "FilterBase": [
+          {
+            "Id": "8728",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "5ac35c7c-33fd-4465-b82b-2c04634c044a",
+              "DataColumn": [
+                {
+                  "Id": "8730",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "345",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8728",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1306",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1519afe2-a4c5-4bf1-b634-3020022bf57f",
+        "FilterBase": [
+          {
+            "Id": "8734",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "a00f0502-1edd-4fe6-beb9-22f23975b4ae",
+              "DataColumn": [
+                {
+                  "Id": "8736",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "359",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "8737",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1310",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3c9f47bd-f711-4da9-8a91-78d70d8a24cd",
+        "FilterBase": [
+          {
+            "Id": "8740",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "abfd1dfc-6010-4b7a-b9c2-4788476d2280",
+              "DataColumn": [
+                {
+                  "Id": "8742",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "373",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "8743",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1314",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d10c172a-e722-43b5-b33a-ff1508dca41e",
+        "FilterBase": [
+          {
+            "Id": "8746",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "f72fda7b-71df-4a2e-83c9-0843dcd123b2",
+              "DataColumn": [
+                {
+                  "Id": "8748",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "391",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "8749",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "1318",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0b2b0c5e-c642-46eb-9572-774b021716e4",
+        "FilterBase": [
+          {
+            "Id": "8752",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "cc5438b0-6a00-406e-8b59-f6f8b98b48a8",
+              "DataColumn": [
+                {
+                  "Id": "8754",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "405",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8752",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8764",
+      "Type": "FilteringScheme",
+      "Fields": {
+        "DocumentNodeId": "5fcce9fa-11f3-459f-9cb8-a528b46c542a",
+        "Items": [
+          {
+            "Id": "8767",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "db22c281-86cc-45df-ad03-83dd273fabfb",
+              "Items": [
+                {
+                  "Id": "8770",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c3ad3532-6594-477d-8c2c-430340328a3e",
+                    "FilterBase": [
+                      {
+                        "Id": "8772",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "af0b06f7-f74c-4296-841c-2160df34f5bb",
+                          "DataColumn": [
+                            {
+                              "Id": "8774",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "174",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8772",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8777",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f0337211-a05f-4a6e-aab2-92cf1c20441b",
+                    "FilterBase": [
+                      {
+                        "Id": "8779",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2413820f-de42-48e3-80cd-36809f03f53c",
+                          "DataColumn": [
+                            {
+                              "Id": "8781",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "215",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8779",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8784",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d27014b3-92c9-4e56-86d9-c35b96c2e0ba",
+                    "FilterBase": [
+                      {
+                        "Id": "8786",
+                        "Type": "TextFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f95b8993-7102-4da5-a282-049c5f78b80d",
+                          "DataColumn": [
+                            {
+                              "Id": "8788",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "229",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": "450"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8789",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "38385403-378c-471f-ad41-11a1ed305e6e",
+                    "FilterBase": [
+                      {
+                        "Id": "8791",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "dea18908-b1ce-4b14-b1ae-f8073aad00d2",
+                          "DataColumn": [
+                            {
+                              "Id": "8793",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "245",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8791",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8796",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ce4173fd-0684-4d65-89d2-a85b94a739dc",
+                    "FilterBase": [
+                      {
+                        "Id": "8798",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "450",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "8799",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "26100e7e-89f5-4bbb-8001-98dee1290612",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "a720631f-3318-436f-9fe7-56e9b144d31b",
+                          "DataColumn": [
+                            {
+                              "Id": "8802",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "261",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8803",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2696f2d3-20e5-4016-bf47-18757a5c6551",
+                    "FilterBase": [
+                      {
+                        "Id": "8805",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "false",
+                          "SearchExpression": "prod",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "8807",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "7e9d99e3-a21e-46ba-881c-ff46004c68ad",
+                                "SelectedValueIndexes": [
+                                  {
+                                    "Id": "8809",
+                                    "Type": "IndexSet",
+                                    "Fields": {
+                                      "Capacity": "16",
+                                      "Count": "1",
+                                      "FullBlockCount": "0",
+                                      "IsReadOnly": "true",
+                                      "First": "9",
+                                      "Last": "9",
+                                      "BlockCount": "1",
+                                      "Blocks": [
+                                        {
+                                          "Id": "8811",
+                                          "Type": "IndexSet+Block",
+                                          "Fields": {
+                                            "Count": "1",
+                                            "Data": []
+                                          },
+                                          "Children": []
+                                        }
+                                      ]
+                                    },
+                                    "Children": []
+                                  }
+                                ],
+                                "FilterTableSelectionColumn": "1113",
+                                "ProducerKey": "1170"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "df94a268-6812-4ee2-9bc2-37a0e898fb76",
+                          "DataColumn": [
+                            {
+                              "Id": "8814",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "279",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8815",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a6e3ec79-6bf8-40f2-87ab-d8476552487c",
+                    "FilterBase": [
+                      {
+                        "Id": "8817",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3cf1a2bd-979e-44f2-92b2-aff214b158df",
+                          "DataColumn": [
+                            {
+                              "Id": "8819",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "297",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8817",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8822",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0de0bec3-4f38-41da-994f-b8f3bec3b1dd",
+                    "FilterBase": [
+                      {
+                        "Id": "8824",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b4b1c873-e758-437e-8d91-a7b91b1218d7",
+                          "DataColumn": [
+                            {
+                              "Id": "8826",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "317",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8718",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8827",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "decf7185-aa80-4688-b46a-f3e68e31a82f",
+                    "FilterBase": [
+                      {
+                        "Id": "8829",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "50061aaa-2557-4efa-9a3a-0551a47c4e9d",
+                          "DataColumn": [
+                            {
+                              "Id": "8831",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "331",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8725",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8832",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b12eda3f-48a4-4280-82b9-c2f91b4b45e7",
+                    "FilterBase": [
+                      {
+                        "Id": "8834",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9b4dd637-e623-426c-805b-f22cec31e88b",
+                          "DataColumn": [
+                            {
+                              "Id": "8836",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "345",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8834",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8839",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "eb28680e-5521-48dc-acd1-c1551d70089b",
+                    "FilterBase": [
+                      {
+                        "Id": "8841",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "52f0c862-d923-4f50-bf33-f473e0cedc2b",
+                          "DataColumn": [
+                            {
+                              "Id": "8843",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "359",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8737",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8844",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1e071197-e065-468f-b633-ff1acf15d111",
+                    "FilterBase": [
+                      {
+                        "Id": "8846",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "509b5b56-1a42-41d1-9728-024ffc6a8c02",
+                          "DataColumn": [
+                            {
+                              "Id": "8848",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "373",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8743",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8849",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "54ca2a88-9c1d-4a50-b331-5087eaa48bb9",
+                    "FilterBase": [
+                      {
+                        "Id": "8851",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "03a570c8-62b9-42a2-8494-90b0f98a8851",
+                          "DataColumn": [
+                            {
+                              "Id": "8853",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "391",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8749",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8854",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "84ce1c83-9167-4c81-b8cf-e7c28fdb9f17",
+                    "FilterBase": [
+                      {
+                        "Id": "8856",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "bffc334d-e6d6-430f-8736-e5185f83864e",
+                          "DataColumn": [
+                            {
+                              "Id": "8858",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "405",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8856",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "128",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "47b95f2d-69ad-4ec4-a4d3-6073ea3050b5",
+                    "DataTable": "118",
+                    "FilterCollection": "8767"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "118",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "8862",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "06393cae-c877-44ea-98b4-058f09e0f981",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ],
+        "DataSelection": "122",
+        "AutoConfigureFilterCollections": "true"
+      },
+      "Children": []
+    },
+    {
+      "Id": "8770",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c3ad3532-6594-477d-8c2c-430340328a3e",
+        "FilterBase": [
+          {
+            "Id": "8772",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "af0b06f7-f74c-4296-841c-2160df34f5bb",
+              "DataColumn": [
+                {
+                  "Id": "8774",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "174",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8772",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8777",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f0337211-a05f-4a6e-aab2-92cf1c20441b",
+        "FilterBase": [
+          {
+            "Id": "8779",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2413820f-de42-48e3-80cd-36809f03f53c",
+              "DataColumn": [
+                {
+                  "Id": "8781",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "215",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8779",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8784",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d27014b3-92c9-4e56-86d9-c35b96c2e0ba",
+        "FilterBase": [
+          {
+            "Id": "8786",
+            "Type": "TextFilter",
+            "Fields": {
+              "DocumentNodeId": "f95b8993-7102-4da5-a282-049c5f78b80d",
+              "DataColumn": [
+                {
+                  "Id": "8788",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "229",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": "450"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8789",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "38385403-378c-471f-ad41-11a1ed305e6e",
+        "FilterBase": [
+          {
+            "Id": "8791",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "dea18908-b1ce-4b14-b1ae-f8073aad00d2",
+              "DataColumn": [
+                {
+                  "Id": "8793",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "245",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8791",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8796",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ce4173fd-0684-4d65-89d2-a85b94a739dc",
+        "FilterBase": [
+          {
+            "Id": "8798",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "true",
+              "SearchExpression": "450",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "8799",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "26100e7e-89f5-4bbb-8001-98dee1290612",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "a720631f-3318-436f-9fe7-56e9b144d31b",
+              "DataColumn": [
+                {
+                  "Id": "8802",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "261",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8803",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2696f2d3-20e5-4016-bf47-18757a5c6551",
+        "FilterBase": [
+          {
+            "Id": "8805",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "false",
+              "SearchExpression": "prod",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "8807",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "7e9d99e3-a21e-46ba-881c-ff46004c68ad",
+                    "SelectedValueIndexes": [
+                      {
+                        "Id": "8809",
+                        "Type": "IndexSet",
+                        "Fields": {
+                          "Capacity": "16",
+                          "Count": "1",
+                          "FullBlockCount": "0",
+                          "IsReadOnly": "true",
+                          "First": "9",
+                          "Last": "9",
+                          "BlockCount": "1",
+                          "Blocks": [
+                            {
+                              "Id": "8811",
+                              "Type": "IndexSet+Block",
+                              "Fields": {
+                                "Count": "1",
+                                "Data": []
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ],
+                    "FilterTableSelectionColumn": "1113",
+                    "ProducerKey": "1170"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "df94a268-6812-4ee2-9bc2-37a0e898fb76",
+              "DataColumn": [
+                {
+                  "Id": "8814",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "279",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8815",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a6e3ec79-6bf8-40f2-87ab-d8476552487c",
+        "FilterBase": [
+          {
+            "Id": "8817",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3cf1a2bd-979e-44f2-92b2-aff214b158df",
+              "DataColumn": [
+                {
+                  "Id": "8819",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "297",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8817",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8822",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0de0bec3-4f38-41da-994f-b8f3bec3b1dd",
+        "FilterBase": [
+          {
+            "Id": "8824",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "b4b1c873-e758-437e-8d91-a7b91b1218d7",
+              "DataColumn": [
+                {
+                  "Id": "8826",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "317",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8718",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8827",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "decf7185-aa80-4688-b46a-f3e68e31a82f",
+        "FilterBase": [
+          {
+            "Id": "8829",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "50061aaa-2557-4efa-9a3a-0551a47c4e9d",
+              "DataColumn": [
+                {
+                  "Id": "8831",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "331",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8725",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8832",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b12eda3f-48a4-4280-82b9-c2f91b4b45e7",
+        "FilterBase": [
+          {
+            "Id": "8834",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9b4dd637-e623-426c-805b-f22cec31e88b",
+              "DataColumn": [
+                {
+                  "Id": "8836",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "345",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8834",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8839",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "eb28680e-5521-48dc-acd1-c1551d70089b",
+        "FilterBase": [
+          {
+            "Id": "8841",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "52f0c862-d923-4f50-bf33-f473e0cedc2b",
+              "DataColumn": [
+                {
+                  "Id": "8843",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "359",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8737",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8844",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1e071197-e065-468f-b633-ff1acf15d111",
+        "FilterBase": [
+          {
+            "Id": "8846",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "509b5b56-1a42-41d1-9728-024ffc6a8c02",
+              "DataColumn": [
+                {
+                  "Id": "8848",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "373",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8743",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8849",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "54ca2a88-9c1d-4a50-b331-5087eaa48bb9",
+        "FilterBase": [
+          {
+            "Id": "8851",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "03a570c8-62b9-42a2-8494-90b0f98a8851",
+              "DataColumn": [
+                {
+                  "Id": "8853",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "391",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8749",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8854",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "84ce1c83-9167-4c81-b8cf-e7c28fdb9f17",
+        "FilterBase": [
+          {
+            "Id": "8856",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "bffc334d-e6d6-430f-8736-e5185f83864e",
+              "DataColumn": [
+                {
+                  "Id": "8858",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "405",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8856",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8865",
+      "Type": "FilteringScheme",
+      "Fields": {
+        "DocumentNodeId": "666a5496-eeaf-4ff4-b8f4-ffaa921113b6",
+        "Items": [
+          {
+            "Id": "8868",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "bf752f4a-da11-4a51-87de-bdbce684a615",
+              "Items": [
+                {
+                  "Id": "8871",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6e150bfc-c949-44a1-ad0f-e2b692dd74ae",
+                    "FilterBase": [
+                      {
+                        "Id": "8873",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "32de3ccd-a11a-4aac-a3c4-c3d09af675fb",
+                          "DataColumn": [
+                            {
+                              "Id": "8875",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "174",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8873",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8878",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f6c7241f-3ddc-4f8c-a618-dbaf75cce049",
+                    "FilterBase": [
+                      {
+                        "Id": "8880",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ba6f4dc1-7911-47f3-bd53-7aff301cdd4a",
+                          "DataColumn": [
+                            {
+                              "Id": "8882",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "215",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8880",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8885",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2d1ed2ce-9f83-48af-a486-42aac056d3a7",
+                    "FilterBase": [
+                      {
+                        "Id": "8887",
+                        "Type": "TextFilter",
+                        "Fields": {
+                          "DocumentNodeId": "401c43eb-a81b-4734-86ea-ef09b8cfed77",
+                          "DataColumn": [
+                            {
+                              "Id": "8889",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "229",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": "450"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8890",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "974899e3-8209-4435-957c-0c6cc250bc0b",
+                    "FilterBase": [
+                      {
+                        "Id": "8892",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d7f40d9f-d2cd-48b1-a1d4-3244ee3b1b6c",
+                          "DataColumn": [
+                            {
+                              "Id": "8894",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "245",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8892",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8897",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "00e6f90d-ecb7-4826-91d3-b33a6006fac0",
+                    "FilterBase": [
+                      {
+                        "Id": "8899",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "450",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "8900",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "9d4cf2ec-984f-467c-a5c8-dae892ec4865",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "59a0bdf0-a452-4b38-9155-aa105db005f2",
+                          "DataColumn": [
+                            {
+                              "Id": "8903",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "261",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8904",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bb588cf5-2cee-4023-a20b-a3714bff78f7",
+                    "FilterBase": [
+                      {
+                        "Id": "8906",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "false",
+                          "SearchExpression": "finance",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "8908",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "e876b841-52e8-4145-a795-b41384a62685",
+                                "SelectedValueIndexes": [
+                                  {
+                                    "Id": "8910",
+                                    "Type": "IndexSet",
+                                    "Fields": {
+                                      "Capacity": "16",
+                                      "Count": "1",
+                                      "FullBlockCount": "0",
+                                      "IsReadOnly": "true",
+                                      "First": "4",
+                                      "Last": "4",
+                                      "BlockCount": "1",
+                                      "Blocks": [
+                                        {
+                                          "Id": "8912",
+                                          "Type": "IndexSet+Block",
+                                          "Fields": {
+                                            "Count": "1",
+                                            "Data": []
+                                          },
+                                          "Children": []
+                                        }
+                                      ]
+                                    },
+                                    "Children": []
+                                  }
+                                ],
+                                "FilterTableSelectionColumn": "1136",
+                                "ProducerKey": "1172"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "9bd9bbde-ebd5-4d51-aaa0-89cc7ff44a19",
+                          "DataColumn": [
+                            {
+                              "Id": "8915",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "279",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8916",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7f755ba4-7338-4d19-83a9-303c910ec2cd",
+                    "FilterBase": [
+                      {
+                        "Id": "8918",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0149c8b4-5e56-45ee-8b18-fbe000dc72e1",
+                          "DataColumn": [
+                            {
+                              "Id": "8920",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "297",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8918",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8923",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f29abe31-fcad-4cec-9085-a0e3905f65b7",
+                    "FilterBase": [
+                      {
+                        "Id": "8925",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "03743bcd-c92c-44b3-83d0-371b981f004a",
+                          "DataColumn": [
+                            {
+                              "Id": "8927",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "317",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8718",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8928",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f21146f4-786e-4754-b121-049bceb3f80b",
+                    "FilterBase": [
+                      {
+                        "Id": "8930",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3f0a9a19-4254-421b-842d-711828f716c9",
+                          "DataColumn": [
+                            {
+                              "Id": "8932",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "331",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8725",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8933",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0a0fbe21-80ee-4595-879c-6679a863abed",
+                    "FilterBase": [
+                      {
+                        "Id": "8935",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "aa65f5a6-bd93-4ce8-84e1-efd5765ff461",
+                          "DataColumn": [
+                            {
+                              "Id": "8937",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "345",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8935",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8940",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7f991415-e60d-498a-a72d-ee9439c5e79f",
+                    "FilterBase": [
+                      {
+                        "Id": "8942",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2dbd9762-aa90-4d05-99e7-caa2f1c3da1c",
+                          "DataColumn": [
+                            {
+                              "Id": "8944",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "359",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8737",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8945",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3dc484ba-a86e-4f2a-a981-5b40b132d97e",
+                    "FilterBase": [
+                      {
+                        "Id": "8947",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "56644602-b8de-40d7-9bf0-cf14ae9427f2",
+                          "DataColumn": [
+                            {
+                              "Id": "8949",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "373",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8743",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8950",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0f434096-504e-4c0d-bddd-2b35257bd0a2",
+                    "FilterBase": [
+                      {
+                        "Id": "8952",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "183abde5-3130-4f9c-9139-292fbd27696f",
+                          "DataColumn": [
+                            {
+                              "Id": "8954",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "391",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8749",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8955",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c72ad0f7-dcbf-49ec-9312-19da649e1241",
+                    "FilterBase": [
+                      {
+                        "Id": "8957",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c0ef99f5-e65b-4e67-bfd9-0ef4ccc1e721",
+                          "DataColumn": [
+                            {
+                              "Id": "8959",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "405",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8957",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "136",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "41c2e898-bb17-47dd-bbda-b2a74293fb28",
+                    "DataTable": "118",
+                    "FilterCollection": "8868"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "118",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "8963",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "dce10a0e-5988-43d9-82bd-30b3e9f4590e",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ],
+        "DataSelection": "130",
+        "AutoConfigureFilterCollections": "true"
+      },
+      "Children": []
+    },
+    {
+      "Id": "8871",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6e150bfc-c949-44a1-ad0f-e2b692dd74ae",
+        "FilterBase": [
+          {
+            "Id": "8873",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "32de3ccd-a11a-4aac-a3c4-c3d09af675fb",
+              "DataColumn": [
+                {
+                  "Id": "8875",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "174",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8873",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8878",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f6c7241f-3ddc-4f8c-a618-dbaf75cce049",
+        "FilterBase": [
+          {
+            "Id": "8880",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "ba6f4dc1-7911-47f3-bd53-7aff301cdd4a",
+              "DataColumn": [
+                {
+                  "Id": "8882",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "215",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8880",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8885",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2d1ed2ce-9f83-48af-a486-42aac056d3a7",
+        "FilterBase": [
+          {
+            "Id": "8887",
+            "Type": "TextFilter",
+            "Fields": {
+              "DocumentNodeId": "401c43eb-a81b-4734-86ea-ef09b8cfed77",
+              "DataColumn": [
+                {
+                  "Id": "8889",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "229",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": "450"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8890",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "974899e3-8209-4435-957c-0c6cc250bc0b",
+        "FilterBase": [
+          {
+            "Id": "8892",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d7f40d9f-d2cd-48b1-a1d4-3244ee3b1b6c",
+              "DataColumn": [
+                {
+                  "Id": "8894",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "245",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8892",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8897",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "00e6f90d-ecb7-4826-91d3-b33a6006fac0",
+        "FilterBase": [
+          {
+            "Id": "8899",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "true",
+              "SearchExpression": "450",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "8900",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "9d4cf2ec-984f-467c-a5c8-dae892ec4865",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "59a0bdf0-a452-4b38-9155-aa105db005f2",
+              "DataColumn": [
+                {
+                  "Id": "8903",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "261",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8904",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bb588cf5-2cee-4023-a20b-a3714bff78f7",
+        "FilterBase": [
+          {
+            "Id": "8906",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "false",
+              "SearchExpression": "finance",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "8908",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "e876b841-52e8-4145-a795-b41384a62685",
+                    "SelectedValueIndexes": [
+                      {
+                        "Id": "8910",
+                        "Type": "IndexSet",
+                        "Fields": {
+                          "Capacity": "16",
+                          "Count": "1",
+                          "FullBlockCount": "0",
+                          "IsReadOnly": "true",
+                          "First": "4",
+                          "Last": "4",
+                          "BlockCount": "1",
+                          "Blocks": [
+                            {
+                              "Id": "8912",
+                              "Type": "IndexSet+Block",
+                              "Fields": {
+                                "Count": "1",
+                                "Data": []
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ],
+                    "FilterTableSelectionColumn": "1136",
+                    "ProducerKey": "1172"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "9bd9bbde-ebd5-4d51-aaa0-89cc7ff44a19",
+              "DataColumn": [
+                {
+                  "Id": "8915",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "279",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8916",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7f755ba4-7338-4d19-83a9-303c910ec2cd",
+        "FilterBase": [
+          {
+            "Id": "8918",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0149c8b4-5e56-45ee-8b18-fbe000dc72e1",
+              "DataColumn": [
+                {
+                  "Id": "8920",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "297",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8918",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8923",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f29abe31-fcad-4cec-9085-a0e3905f65b7",
+        "FilterBase": [
+          {
+            "Id": "8925",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "03743bcd-c92c-44b3-83d0-371b981f004a",
+              "DataColumn": [
+                {
+                  "Id": "8927",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "317",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8718",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8928",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f21146f4-786e-4754-b121-049bceb3f80b",
+        "FilterBase": [
+          {
+            "Id": "8930",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "3f0a9a19-4254-421b-842d-711828f716c9",
+              "DataColumn": [
+                {
+                  "Id": "8932",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "331",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8725",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8933",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0a0fbe21-80ee-4595-879c-6679a863abed",
+        "FilterBase": [
+          {
+            "Id": "8935",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "aa65f5a6-bd93-4ce8-84e1-efd5765ff461",
+              "DataColumn": [
+                {
+                  "Id": "8937",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "345",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8935",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8940",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7f991415-e60d-498a-a72d-ee9439c5e79f",
+        "FilterBase": [
+          {
+            "Id": "8942",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "2dbd9762-aa90-4d05-99e7-caa2f1c3da1c",
+              "DataColumn": [
+                {
+                  "Id": "8944",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "359",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8737",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8945",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3dc484ba-a86e-4f2a-a981-5b40b132d97e",
+        "FilterBase": [
+          {
+            "Id": "8947",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "56644602-b8de-40d7-9bf0-cf14ae9427f2",
+              "DataColumn": [
+                {
+                  "Id": "8949",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "373",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8743",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8950",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0f434096-504e-4c0d-bddd-2b35257bd0a2",
+        "FilterBase": [
+          {
+            "Id": "8952",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "183abde5-3130-4f9c-9139-292fbd27696f",
+              "DataColumn": [
+                {
+                  "Id": "8954",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "391",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8749",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8955",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c72ad0f7-dcbf-49ec-9312-19da649e1241",
+        "FilterBase": [
+          {
+            "Id": "8957",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c0ef99f5-e65b-4e67-bfd9-0ef4ccc1e721",
+              "DataColumn": [
+                {
+                  "Id": "8959",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "405",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8957",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8966",
+      "Type": "FilteringScheme",
+      "Fields": {
+        "DocumentNodeId": "ddb709bf-b51c-4532-a570-0f341a73778e",
+        "Items": [
+          {
+            "Id": "8969",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "3d060956-9b8a-44f1-b7ad-f7958ee4aab8",
+              "Items": [
+                {
+                  "Id": "8972",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "42f013fb-5fc5-4e15-b2c0-ca0d61bf4f74",
+                    "FilterBase": [
+                      {
+                        "Id": "8974",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9d9a7e8c-b2d1-4e81-aca6-11d5a4f0dc6c",
+                          "DataColumn": [
+                            {
+                              "Id": "8976",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "174",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8974",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8979",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4cbc100d-3278-48b1-80ad-48be9f2021e1",
+                    "FilterBase": [
+                      {
+                        "Id": "8981",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "18010258-b488-4858-8138-22a73a7d5b92",
+                          "DataColumn": [
+                            {
+                              "Id": "8983",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "215",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8981",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8986",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "dd3b36e3-2543-4a96-a9dc-15eb5420bce4",
+                    "FilterBase": [
+                      {
+                        "Id": "8988",
+                        "Type": "TextFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1dd3e7b8-18b8-44e5-9eb2-e4e58fc95291",
+                          "DataColumn": [
+                            {
+                              "Id": "8990",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "229",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": "450"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8991",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a323bbfa-85ac-4eb2-9e0b-facd713e5416",
+                    "FilterBase": [
+                      {
+                        "Id": "8993",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f24eeb04-ac40-4d8c-b074-8fce54a1663d",
+                          "DataColumn": [
+                            {
+                              "Id": "8995",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "245",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "8993",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8998",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "39044d67-42b7-4f9d-b8a8-f38a52176e7d",
+                    "FilterBase": [
+                      {
+                        "Id": "9000",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "450",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "9001",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "0542a098-fc6f-47e2-abea-1c622022163f",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "a40fe13f-cee8-4284-b874-7d9a01805246",
+                          "DataColumn": [
+                            {
+                              "Id": "9004",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "261",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9005",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "56782fe9-5c6f-4193-931b-0a8ad1c4520f",
+                    "FilterBase": [
+                      {
+                        "Id": "9007",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "false",
+                          "SearchExpression": "marketing",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "9009",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "36294395-6ccc-4fb8-a1ea-c76b56a81105",
+                                "SelectedValueIndexes": [
+                                  {
+                                    "Id": "9011",
+                                    "Type": "IndexSet",
+                                    "Fields": {
+                                      "Capacity": "16",
+                                      "Count": "1",
+                                      "FullBlockCount": "0",
+                                      "IsReadOnly": "true",
+                                      "First": "8",
+                                      "Last": "8",
+                                      "BlockCount": "1",
+                                      "Blocks": [
+                                        {
+                                          "Id": "9013",
+                                          "Type": "IndexSet+Block",
+                                          "Fields": {
+                                            "Count": "1",
+                                            "Data": []
+                                          },
+                                          "Children": []
+                                        }
+                                      ]
+                                    },
+                                    "Children": []
+                                  }
+                                ],
+                                "FilterTableSelectionColumn": "1159",
+                                "ProducerKey": "1174"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "1aa3025f-b9d9-4866-96e9-627f358cd67f",
+                          "DataColumn": [
+                            {
+                              "Id": "9016",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "279",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9017",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b30da588-a7de-49bd-bdc3-598cc089d992",
+                    "FilterBase": [
+                      {
+                        "Id": "9019",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0301a06a-9511-46a0-80e8-84b2751d8a89",
+                          "DataColumn": [
+                            {
+                              "Id": "9021",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "297",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "9019",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9024",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9cb29b49-e2f9-4670-97ec-0ab6730e6290",
+                    "FilterBase": [
+                      {
+                        "Id": "9026",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "20bddc1b-8fb7-4334-bd90-d8d980696b21",
+                          "DataColumn": [
+                            {
+                              "Id": "9028",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "317",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8718",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9029",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "db19bbb7-e27f-407c-9d74-b9e81f15c9f5",
+                    "FilterBase": [
+                      {
+                        "Id": "9031",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "64b19417-b6c4-4fd4-867e-5b4c966cebc5",
+                          "DataColumn": [
+                            {
+                              "Id": "9033",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "331",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8725",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9034",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d10968da-adf1-47c3-85d6-ff33533bc1f7",
+                    "FilterBase": [
+                      {
+                        "Id": "9036",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8cd46e8e-03e7-48c9-b7de-7b807d783995",
+                          "DataColumn": [
+                            {
+                              "Id": "9038",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "345",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "9036",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9041",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e091b186-e4a5-4435-bc1b-234cc510dfe8",
+                    "FilterBase": [
+                      {
+                        "Id": "9043",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d7b4678e-d543-4fcc-bc05-8c35d1a26359",
+                          "DataColumn": [
+                            {
+                              "Id": "9045",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "359",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8737",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9046",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f4f53632-3a05-4e28-8736-3f39f6917ba4",
+                    "FilterBase": [
+                      {
+                        "Id": "9048",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "73779f1b-700f-455b-b927-41b516920f5e",
+                          "DataColumn": [
+                            {
+                              "Id": "9050",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "373",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8743",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9051",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b76757df-bb81-4140-b860-b8b23501a6f6",
+                    "FilterBase": [
+                      {
+                        "Id": "9053",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2c819ede-1fd2-4f9c-9b26-be059dddf71a",
+                          "DataColumn": [
+                            {
+                              "Id": "9055",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "391",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": "8749",
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "9056",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "205bc965-756d-473b-8420-ee3a03dba995",
+                    "FilterBase": [
+                      {
+                        "Id": "9058",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "e09c3097-2620-4762-95b2-adc1f217c4be",
+                          "DataColumn": [
+                            {
+                              "Id": "9060",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "405",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "9058",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "144",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "d7940482-316c-415e-9fd6-1051f07a96e5",
+                    "DataTable": "118",
+                    "FilterCollection": "8969"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "118",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "9064",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "b737c06a-1b60-44f6-aa56-5de47c169d42",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ],
+        "DataSelection": "138",
+        "AutoConfigureFilterCollections": "true"
+      },
+      "Children": []
+    },
+    {
+      "Id": "8972",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "42f013fb-5fc5-4e15-b2c0-ca0d61bf4f74",
+        "FilterBase": [
+          {
+            "Id": "8974",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9d9a7e8c-b2d1-4e81-aca6-11d5a4f0dc6c",
+              "DataColumn": [
+                {
+                  "Id": "8976",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "174",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8974",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8979",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4cbc100d-3278-48b1-80ad-48be9f2021e1",
+        "FilterBase": [
+          {
+            "Id": "8981",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "18010258-b488-4858-8138-22a73a7d5b92",
+              "DataColumn": [
+                {
+                  "Id": "8983",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "215",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8981",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8986",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "dd3b36e3-2543-4a96-a9dc-15eb5420bce4",
+        "FilterBase": [
+          {
+            "Id": "8988",
+            "Type": "TextFilter",
+            "Fields": {
+              "DocumentNodeId": "1dd3e7b8-18b8-44e5-9eb2-e4e58fc95291",
+              "DataColumn": [
+                {
+                  "Id": "8990",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "229",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": "450"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8991",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a323bbfa-85ac-4eb2-9e0b-facd713e5416",
+        "FilterBase": [
+          {
+            "Id": "8993",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "f24eeb04-ac40-4d8c-b074-8fce54a1663d",
+              "DataColumn": [
+                {
+                  "Id": "8995",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "245",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "8993",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8998",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "39044d67-42b7-4f9d-b8a8-f38a52176e7d",
+        "FilterBase": [
+          {
+            "Id": "9000",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "true",
+              "SearchExpression": "450",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "9001",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "0542a098-fc6f-47e2-abea-1c622022163f",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "a40fe13f-cee8-4284-b874-7d9a01805246",
+              "DataColumn": [
+                {
+                  "Id": "9004",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "261",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9005",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "56782fe9-5c6f-4193-931b-0a8ad1c4520f",
+        "FilterBase": [
+          {
+            "Id": "9007",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "false",
+              "SearchExpression": "marketing",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "9009",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "36294395-6ccc-4fb8-a1ea-c76b56a81105",
+                    "SelectedValueIndexes": [
+                      {
+                        "Id": "9011",
+                        "Type": "IndexSet",
+                        "Fields": {
+                          "Capacity": "16",
+                          "Count": "1",
+                          "FullBlockCount": "0",
+                          "IsReadOnly": "true",
+                          "First": "8",
+                          "Last": "8",
+                          "BlockCount": "1",
+                          "Blocks": [
+                            {
+                              "Id": "9013",
+                              "Type": "IndexSet+Block",
+                              "Fields": {
+                                "Count": "1",
+                                "Data": []
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ],
+                    "FilterTableSelectionColumn": "1159",
+                    "ProducerKey": "1174"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "1aa3025f-b9d9-4866-96e9-627f358cd67f",
+              "DataColumn": [
+                {
+                  "Id": "9016",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "279",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9017",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b30da588-a7de-49bd-bdc3-598cc089d992",
+        "FilterBase": [
+          {
+            "Id": "9019",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0301a06a-9511-46a0-80e8-84b2751d8a89",
+              "DataColumn": [
+                {
+                  "Id": "9021",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "297",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "9019",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9024",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9cb29b49-e2f9-4670-97ec-0ab6730e6290",
+        "FilterBase": [
+          {
+            "Id": "9026",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "20bddc1b-8fb7-4334-bd90-d8d980696b21",
+              "DataColumn": [
+                {
+                  "Id": "9028",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "317",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8718",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9029",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "db19bbb7-e27f-407c-9d74-b9e81f15c9f5",
+        "FilterBase": [
+          {
+            "Id": "9031",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "64b19417-b6c4-4fd4-867e-5b4c966cebc5",
+              "DataColumn": [
+                {
+                  "Id": "9033",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "331",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8725",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9034",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d10968da-adf1-47c3-85d6-ff33533bc1f7",
+        "FilterBase": [
+          {
+            "Id": "9036",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "8cd46e8e-03e7-48c9-b7de-7b807d783995",
+              "DataColumn": [
+                {
+                  "Id": "9038",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "345",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "9036",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9041",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e091b186-e4a5-4435-bc1b-234cc510dfe8",
+        "FilterBase": [
+          {
+            "Id": "9043",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "d7b4678e-d543-4fcc-bc05-8c35d1a26359",
+              "DataColumn": [
+                {
+                  "Id": "9045",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "359",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8737",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9046",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f4f53632-3a05-4e28-8736-3f39f6917ba4",
+        "FilterBase": [
+          {
+            "Id": "9048",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "73779f1b-700f-455b-b927-41b516920f5e",
+              "DataColumn": [
+                {
+                  "Id": "9050",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "373",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8743",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9051",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b76757df-bb81-4140-b860-b8b23501a6f6",
+        "FilterBase": [
+          {
+            "Id": "9053",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "2c819ede-1fd2-4f9c-9b26-be059dddf71a",
+              "DataColumn": [
+                {
+                  "Id": "9055",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "391",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": "8749",
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "9056",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "205bc965-756d-473b-8420-ee3a03dba995",
+        "FilterBase": [
+          {
+            "Id": "9058",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "e09c3097-2620-4762-95b2-adc1f217c4be",
+              "DataColumn": [
+                {
+                  "Id": "9060",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "405",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "9058",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    }
+  ],
   "Bookmarks": [],
   "Scripts": []
 }

--- a/im_output/Sales and Marketing_IM.json
+++ b/im_output/Sales and Marketing_IM.json
@@ -1,7 +1,20159 @@
 {
-  "DataTables": [],
-  "Visualizations": [],
-  "Filters": [],
+  "DataTables": [
+    {
+      "Id": "90",
+      "Name": "SalesAndMarketing",
+      "DataSource": "",
+      "Transformations": [],
+      "Columns": [
+        {
+          "Name": "Store ID",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Store Name",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "City",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "State",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Region",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Store Type",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Rank",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Class Sales Year 1",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Class Sales",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Class Change Yr 1 to Yr 2",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Brand A Yr 1",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Brand A Yr 2",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Brand A Change Yr 1 to Yr 2",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Brand A Share Yr 1",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Brand A Share Yr 2",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Brand A Share Change Yr 1 to Yr 2",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Sales Person ID",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Territory",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Promotions",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "zip3",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "X",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "Y",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "ZipGroup3Digit",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "Variance from Territory",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "To Call",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "Market Segments",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "BCG segmentation",
+          "DataType": "String",
+          "Expression": ""
+        }
+      ],
+      "Relationships": []
+    },
+    {
+      "Id": "305",
+      "Name": "usa_st",
+      "DataSource": "",
+      "Transformations": [],
+      "Columns": [
+        {
+          "Name": "Geometry",
+          "DataType": "Binary",
+          "Expression": ""
+        },
+        {
+          "Name": "AREA",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "STATE_NAME",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "STATE_FIPS",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "SUB_REGION",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "STATE_ABBR",
+          "DataType": "String",
+          "Expression": ""
+        },
+        {
+          "Name": "POP1990",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "POP1997",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "POP90_SQMI",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "HOUSEHOLDS",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MALES",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "FEMALES",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "WHITE",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "BLACK",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AMERI_ES",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "ASIAN_PI",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "OTHER",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "HISPANIC",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AGE_UNDER5",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AGE_5_17",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AGE_18_29",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AGE_30_49",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AGE_50_64",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AGE_65_UP",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "NEVERMARRY",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MARRIED",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "SEPARATED",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "WIDOWED",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "DIVORCED",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "HSEHLD_1_M",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "HSEHLD_1_F",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MARHH_CHD",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MARHH_NO_C",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MHH_CHILD",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "FHH_CHILD",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "HSE_UNITS",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "VACANT",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "OWNER_OCC",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "RENTER_OCC",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MEDIAN_VAL",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MEDIANRENT",
+          "DataType": "Integer",
+          "Expression": ""
+        },
+        {
+          "Name": "UNITS_1DET",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "UNITS_1ATT",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "UNITS2",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "UNITS3_9",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "UNITS10_49",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "UNITS50_UP",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "MOBILEHOME",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "NO_FARMS87",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AVG_SIZE87",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "CROP_ACR87",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "AVG_SALE87",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "XMin",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "XMax",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "YMin",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "YMax",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "XCenter",
+          "DataType": "Real",
+          "Expression": ""
+        },
+        {
+          "Name": "YCenter",
+          "DataType": "Real",
+          "Expression": ""
+        }
+      ],
+      "Relationships": []
+    }
+  ],
+  "Visualizations": [
+    {
+      "Id": "9605",
+      "Type": "BarChart",
+      "DataTable": [
+        {
+          "Id": "9629",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "bf05b79b-0e5e-4b9d-ad14-0692b90d7726",
+            "DataTable": "90",
+            "UseActiveFiltering": "true",
+            "ActiveFiltering": "320",
+            "Filterings": [
+              {
+                "Id": "9631",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "8e197851-a321-4a9f-8aaa-1475e88b28ea",
+                  "Items": [
+                    {
+                      "Id": "9634",
+                      "Type": "VisualizationFilteringCollection+VisualizationFilteringReference",
+                      "Fields": {
+                        "DocumentNodeId": "a480d9ba-0851-40e2-94d1-f063fe65b740",
+                        "Reference": "62"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "9636",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "8a7c6a8e-dacd-4305-ad4d-f4c7b937204f",
+                  "Items": [
+                    {
+                      "Id": "9639",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "88cdf9ea-f7d8-4b6d-ba62-6eb4f40d5df1",
+                        "ManualDisplayName": "918",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "9641",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "ca53acbd-e0ea-473f-95f0-f16be66fecb7",
+                        "ManualDisplayName": "918",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "9643",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "f8d12641-c4e3-47b8-bd64-68317a5cbcad",
+                        "ManualDisplayName": "918",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "195",
+            "FilteringsLegendItem": [
+              {
+                "Id": "9645",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "704f0dc3-cc9f-40e4-ab75-925bf295afe7",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "9647",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "b697b98b-ec6b-401f-a922-1ad39affbfdd",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "9649",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "33faa95b-0463-4696-ae34-e2d08be8dd30",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "9651",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "9c83c27d-e2e5-408d-8f74-df4bdbf1824b",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyMessageFont": "",
+            "LimitingMarkingsEmptyBehavior": "ShowMessage",
+            "LimitingMarkingsEmptyMessage": "In the table above, select the values for the territories you want to view details for.",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "9656",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "f7be7f05-7d1f-4eb0-9553-23628f26ee10",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "9667",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "0951a898-0d61-4188-8033-82d810ac88fb",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "9669",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "d19fb658-cb0b-4c6c-afa2-2e5445d93400",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "9671",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "b5befeaa-3b51-4f4e-aab8-4fb5dfee71a1",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "9682",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "6918e743-a0b2-452e-8995-94bfeb815431",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "9693",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "24e47042-d01f-4009-93d0-1c0a331d7d90",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "9695",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "f294cdaf-2183-4f56-ac08-1ca20b929438",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "9706",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "34665d2e-6c74-40d0-a2a8-e4d51ceb27d0",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "9717",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "0f077d10-bd93-4b06-80d2-1a548ce5bb76",
+              "Visible": "true",
+              "Dock": "6733",
+              "Width": "115",
+              "Font": "",
+              "Items": [
+                {
+                  "Id": "9720",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "bc5b4b94-7002-4285-9ca6-7e7ed4591eb2",
+                    "Items": [
+                      {
+                        "Id": "9723",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "1a952629-d72d-4225-981d-5c30311aeec4",
+                          "Item": "9725"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9726",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "9e0987de-e9ef-4044-b626-2fe6e52ef0b7",
+                          "Item": "9728"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9729",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "dfb43480-9b82-491d-a341-f57cbd9d12dc",
+                          "Item": "9645"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9731",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "3daba1cf-31d6-44ba-9928-e95929db1070",
+                          "Item": "9647"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9733",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "7efc5644-d674-474b-a276-59fac3124a28",
+                          "Item": "9649"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9735",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "7badc74b-dbb3-46fc-b554-651468ec1499",
+                          "Item": "9737"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9738",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "11ce1d74-727b-41e7-bee8-40b63224b8fc",
+                          "Item": "9740"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9741",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "ec789f4b-9c01-4698-8ac0-e535bd2f1d33",
+                          "Item": "9743"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9744",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "ad20f4e2-d9e2-4e73-9cfb-eb2390d6035e",
+                          "Item": "9746"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "9747",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "c90996c2-b0b4-4254-8799-3610fce76f86",
+                          "Item": "9749"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    },
+    {
+      "Id": "11766",
+      "Type": "BarChart",
+      "DataTable": [
+        {
+          "Id": "11781",
+          "Type": "VisualizationData",
+          "Fields": {
+            "DocumentNodeId": "213420af-e871-4ae2-8192-b52010fffede",
+            "DataTable": "90",
+            "UseActiveFiltering": "true",
+            "ActiveFiltering": "295",
+            "Filterings": [
+              {
+                "Id": "11783",
+                "Type": "VisualizationFilteringCollection",
+                "Fields": {
+                  "DocumentNodeId": "193c8a71-275a-4b15-8c96-f8354379ec3e",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "Subsets": [
+              {
+                "Id": "11786",
+                "Type": "VisualizationSubsetCollection",
+                "Fields": {
+                  "DocumentNodeId": "41e97a28-97df-44df-816e-fba53ab24c8f",
+                  "Items": [
+                    {
+                      "Id": "11789",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "5ca97a9e-632a-4191-8d40-02060072ed3a",
+                        "ManualDisplayName": "918",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "All"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "11791",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "8e60ded2-4615-412a-81f4-9d4978bf7642",
+                        "ManualDisplayName": "918",
+                        "Enabled": "false",
+                        "Interactive": "true",
+                        "Type": "DefaultComplement"
+                      },
+                      "Children": []
+                    },
+                    {
+                      "Id": "11793",
+                      "Type": "DefaultVisualizationSubset",
+                      "Fields": {
+                        "DocumentNodeId": "2feddaf9-2f36-4559-8a5e-1fa956f0a892",
+                        "ManualDisplayName": "918",
+                        "Enabled": "true",
+                        "Interactive": "true",
+                        "Type": "Default"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ],
+            "Marking": "62",
+            "FilteringsLegendItem": [
+              {
+                "Id": "11795",
+                "Type": "LegendFilteringsItem",
+                "Fields": {
+                  "DocumentNodeId": "c2df3310-580f-43dc-a7a6-c41be5554db7",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "DataTableLegendItem": [
+              {
+                "Id": "11797",
+                "Type": "LegendDataTableItem",
+                "Fields": {
+                  "DocumentNodeId": "676dfc57-7d6c-42f7-8f5a-e55aecec16cf",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingLegendItem": [
+              {
+                "Id": "11799",
+                "Type": "LegendMarkingItem",
+                "Fields": {
+                  "DocumentNodeId": "05baa3d4-3424-4273-bb49-8cbfac4e4c24",
+                  "Visible": "false",
+                  "ShowTitle": "true",
+                  "ShowSubItemsInHorizontalLegend": "false"
+                },
+                "Children": []
+              }
+            ],
+            "MarkingCombinationMethod": "Intersection",
+            "WhereClauseExpression": "0",
+            "relations": [
+              {
+                "Id": "11801",
+                "Type": "VisualizationRelations",
+                "Fields": {
+                  "DocumentNodeId": "c64b52e6-7a83-4aec-b7d8-cb76c0865a9c",
+                  "Items": []
+                },
+                "Children": []
+              }
+            ],
+            "LimitingMarkingsEmptyMessageFont": "",
+            "LimitingMarkingsEmptyBehavior": "ShowEmpty",
+            "LimitingMarkingsEmptyMessage": "Mark items to view details here.",
+            "WhereClauseNameMapper": [
+              {
+                "Id": "11806",
+                "Type": "QualifiedNameMapper",
+                "Fields": {
+                  "DocumentNodeId": "929d2adb-cf8e-4331-a232-7376b81521e0",
+                  "Columns": [],
+                  "Hierarchies": [],
+                  "ColumnProperties2": [],
+                  "TableProperties2": [],
+                  "DocumentProperties2": [],
+                  "ImplicitDocumentProperties": [],
+                  "Tables": [],
+                  "ColumnSearchTables": [],
+                  "FunctionReferences": []
+                },
+                "Children": []
+              }
+            ],
+            "WhenClause": [
+              {
+                "Id": "11817",
+                "Type": "WhenClause",
+                "Fields": {
+                  "DocumentNodeId": "23964389-72b4-4b23-8cfa-8130c41324da",
+                  "Column": "0",
+                  "Start": [
+                    {
+                      "Id": "11819",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "2c993702-1000-4173-a44b-13ccc3b4e7b4",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "11821",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "1920d4b3-e54a-4d15-92c7-3aa3ae92a37f",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "11832",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "cbbcac32-ef03-440f-98f1-10600f558fef",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ],
+                  "End": [
+                    {
+                      "Id": "11843",
+                      "Type": "ManagedExpression",
+                      "Fields": {
+                        "DocumentNodeId": "df810162-48b6-46ef-9298-281d50ab3934",
+                        "Expression": "0",
+                        "PreProcessedExpression": "0",
+                        "TableReference": "0",
+                        "NameMapper": [
+                          {
+                            "Id": "11845",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "aa9904d2-5af6-4820-be3d-55227e75ed3e",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreProcessorNameMapper": [
+                          {
+                            "Id": "11856",
+                            "Type": "NameMapper",
+                            "Fields": {
+                              "DocumentNodeId": "6fef585c-efa0-4f3a-9406-4554db11e235",
+                              "Columns": [],
+                              "Hierarchies": [],
+                              "ColumnProperties2": [],
+                              "TableProperties2": [],
+                              "DocumentProperties2": [],
+                              "ImplicitDocumentProperties": [],
+                              "Tables": [],
+                              "ColumnSearchTables": [],
+                              "FunctionReferences": []
+                            },
+                            "Children": []
+                          }
+                        ],
+                        "PreprocessorParts": "0"
+                      },
+                      "Children": []
+                    }
+                  ]
+                },
+                "Children": []
+              }
+            ]
+          },
+          "Children": []
+        }
+      ],
+      "Bindings": {
+        "Legend": [
+          {
+            "Id": "11867",
+            "Type": "Legend",
+            "Fields": {
+              "DocumentNodeId": "86e0b9e1-c2a2-4139-bb2e-d29262de6f4a",
+              "Visible": "false",
+              "Dock": "6733",
+              "Width": "150",
+              "Font": "",
+              "Items": [
+                {
+                  "Id": "11870",
+                  "Type": "Legend+LegendItemCollection",
+                  "Fields": {
+                    "DocumentNodeId": "89488723-64a3-46b4-b888-87c8a94855fd",
+                    "Items": [
+                      {
+                        "Id": "11873",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "3273b401-8b74-4d8f-a1df-f41c5eed99ea",
+                          "Item": "11875"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11876",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "1c39f07a-47be-4ebc-a46b-a12f833f5689",
+                          "Item": "11878"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11879",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "c7c892ca-ba2c-47ff-b4ee-d920b22a035e",
+                          "Item": "11795"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11881",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "5e7bad79-c0f3-4b51-a300-fb668575018f",
+                          "Item": "11797"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11883",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "b83ec903-90d1-4c64-93cb-eb2f89dcc56e",
+                          "Item": "11799"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11885",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "dbaef6c9-9417-45a4-b06e-c08bd17ad7cc",
+                          "Item": "11887"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11888",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "0860dcb0-7e33-4c16-b391-f4c6cde78afd",
+                          "Item": "11890"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11891",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "49d8d3cf-5d1d-4b87-8c7e-8f486856c0c8",
+                          "Item": "11893"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11894",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "f48960be-9f0a-46fb-a175-3ac65e2d5f7b",
+                          "Item": "11896"
+                        },
+                        "Children": []
+                      },
+                      {
+                        "Id": "11897",
+                        "Type": "Legend+LegendItemReference",
+                        "Fields": {
+                          "DocumentNodeId": "832cbdcd-56ba-46b8-a6b8-5b01a8f11f82",
+                          "Item": "11899"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "MaxValuesPerLegendItem": "29"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Filters": "",
+      "Formatting": ""
+    }
+  ],
+  "Filters": [
+    {
+      "Id": "4030",
+      "Type": "FilteringScheme",
+      "Fields": {
+        "DocumentNodeId": "69aa81ce-aee1-42f3-81f8-945bb3faa4d7",
+        "Items": [
+          {
+            "Id": "4177",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "8015e7a8-a4dd-4ea5-b621-97c0df6bb6c3",
+              "Items": [
+                {
+                  "Id": "4066",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b638efd8-562a-4418-b725-86244df9bac8",
+                    "FilterBase": [
+                      {
+                        "Id": "12730",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f1ce7e9a-f7b1-4f23-b12e-17e25bcb2394",
+                          "DataColumn": [
+                            {
+                              "Id": "12736",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "407",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "12737",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4062",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5a294557-ac43-422a-a989-6155c985e6c6",
+                    "FilterBase": [
+                      {
+                        "Id": "12740",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ec4969ee-3fdc-4f6b-9883-43fec1098d74",
+                          "DataColumn": [
+                            {
+                              "Id": "12742",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "114",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "12743",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4043",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "05ac4166-f776-49c1-8b83-577edf739d29",
+                    "FilterBase": [
+                      {
+                        "Id": "12745",
+                        "Type": "RadioButtonFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b8c7dd86-b368-44c5-adda-4de28f2348d8",
+                          "DataColumn": [
+                            {
+                              "Id": "12748",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "173",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "12749",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4051",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "18911405-b5cf-4b94-aae7-89cf72fbe619",
+                    "FilterBase": [
+                      {
+                        "Id": "12751",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d78a7fab-d763-4036-a897-aff2c8ac98f1",
+                          "DataColumn": [
+                            {
+                              "Id": "12754",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "527",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12751",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4047",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "af551016-9987-49c8-b708-7c8eabb5b7ac",
+                    "FilterBase": [
+                      {
+                        "Id": "12765",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6c5c6ca5-d24a-408a-9f82-15b93f58b6cf",
+                          "DataColumn": [
+                            {
+                              "Id": "12767",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "563",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12765",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4108",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1b4652b3-7d5c-4bad-9e03-8e10c6dfda9c",
+                    "FilterBase": [
+                      {
+                        "Id": "12773",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1edc85f7-8001-4429-9c7e-a7a4ddffd83f",
+                          "DataColumn": [
+                            {
+                              "Id": "12775",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "581",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12773",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4112",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e84f508f-cd8e-462e-aef5-95a3c258b452",
+                    "FilterBase": [
+                      {
+                        "Id": "12781",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1476afdb-91f9-4510-bc7b-af320526fc56",
+                          "DataColumn": [
+                            {
+                              "Id": "12783",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "599",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12781",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4116",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0c780e34-5f64-4643-9fcb-14dc59b27596",
+                    "FilterBase": [
+                      {
+                        "Id": "12789",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "547971ae-5e82-4796-b492-54286db155b9",
+                          "DataColumn": [
+                            {
+                              "Id": "12791",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "617",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12789",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4120",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e23a5850-6411-4a00-9e2e-0154b7d7ce86",
+                    "FilterBase": [
+                      {
+                        "Id": "12797",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "10f45675-0c8f-4b9d-80b8-3a5de80242e6",
+                          "DataColumn": [
+                            {
+                              "Id": "12799",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "635",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12797",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4124",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ba3bffa7-6b3f-4635-b568-075c667a027f",
+                    "FilterBase": [
+                      {
+                        "Id": "12805",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "5448e841-ca8f-43ea-aed1-3862388f6b29",
+                          "DataColumn": [
+                            {
+                              "Id": "12807",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "653",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12805",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4128",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "22f86b65-c74f-4fed-8620-e2eae415432b",
+                    "FilterBase": [
+                      {
+                        "Id": "12813",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "eaaa0740-1db8-4bef-9b10-61a4f4cbaee3",
+                          "DataColumn": [
+                            {
+                              "Id": "12815",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "671",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12813",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4132",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f3f5a7dd-2209-48c9-baf1-3abc890c41b1",
+                    "FilterBase": [
+                      {
+                        "Id": "12821",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3cc2a8c9-d99d-45fb-9a13-924944f131b4",
+                          "DataColumn": [
+                            {
+                              "Id": "12823",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "689",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12821",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4136",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c3f7bdf8-cdcb-463e-b5ec-d3d380559282",
+                    "FilterBase": [
+                      {
+                        "Id": "12829",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "fd77374b-dc63-4a87-b34e-5c6e7685d67c",
+                          "DataColumn": [
+                            {
+                              "Id": "12831",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "707",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12829",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4070",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a37b847b-3b99-417a-91ce-1516eaede1b7",
+                    "FilterBase": [
+                      {
+                        "Id": "12837",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6db7c716-03e4-41e4-a0d8-041083b99f67",
+                          "DataColumn": [
+                            {
+                              "Id": "12839",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "158",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "12840",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4074",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6a3d9640-0e46-4b38-94c0-609a2e56680c",
+                    "FilterBase": [
+                      {
+                        "Id": "12842",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "021750ef-5202-408c-9b2f-d4a8ea3bac3a",
+                          "DataColumn": [
+                            {
+                              "Id": "12844",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "760",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12842",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4078",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "321fea7e-a452-4b53-b0e4-0b1e80711e8a",
+                    "FilterBase": [
+                      {
+                        "Id": "12850",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2aac32e8-2105-44e3-aa0f-d54a53d5bdc9",
+                          "DataColumn": [
+                            {
+                              "Id": "12852",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "782",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12850",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4082",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "69ed8f39-a5af-4ef7-bd6c-43f749591cb0",
+                    "FilterBase": [
+                      {
+                        "Id": "12858",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2c64af67-afab-4560-8e43-cb1dd9b564af",
+                          "DataColumn": [
+                            {
+                              "Id": "12860",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "806",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12858",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4086",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "13d14061-6dbb-4bd2-9e21-f97e3b7e4662",
+                    "FilterBase": [
+                      {
+                        "Id": "12866",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "72608b5c-6ca6-4aa9-a600-ad5687ab4f2d",
+                          "DataColumn": [
+                            {
+                              "Id": "12868",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "828",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12866",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4140",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "51945bbe-963e-482a-a3ec-3b437919e820",
+                    "FilterBase": [
+                      {
+                        "Id": "12874",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ca71466d-732d-4770-a9e5-e797762079a7",
+                          "DataColumn": [
+                            {
+                              "Id": "12876",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "846",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12874",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4097",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "dbf0ba9a-c372-4b7f-95c6-90ee0b2aa1b1",
+                    "FilterBase": [
+                      {
+                        "Id": "12882",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8886b0d9-712b-4966-a852-437583bfa8be",
+                          "DataColumn": [
+                            {
+                              "Id": "12885",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "247",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "12886",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4152",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6684b17d-1fcc-4cf4-ace5-0f9f4cbaa125",
+                    "FilterBase": [
+                      {
+                        "Id": "12890",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "77b8262a-aa26-448c-9bb7-73fa30601ca3",
+                          "DataColumn": [
+                            {
+                              "Id": "12892",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "357",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12890",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4156",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2ec69f66-6078-4ee5-9058-612ae7c67138",
+                    "FilterBase": [
+                      {
+                        "Id": "12898",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a42e3004-fdaf-40dc-83b0-34bcbc36dd3e",
+                          "DataColumn": [
+                            {
+                              "Id": "12900",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "262",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "12901",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4160",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "fd963f51-45a8-4d74-b057-eccb84da4113",
+                    "FilterBase": [
+                      {
+                        "Id": "12903",
+                        "Type": "RadioButtonFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8b0d2789-1cdb-4aeb-8734-e540041855b3",
+                          "DataColumn": [
+                            {
+                              "Id": "12905",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "505",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "12906",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4164",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3e3842e3-819b-4967-bdaf-b7695c730d4d",
+                    "FilterBase": [
+                      {
+                        "Id": "12908",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9f3e54e7-a740-4f6f-be42-1ce217af54d1",
+                          "DataColumn": [
+                            {
+                              "Id": "12910",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "545",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12908",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4168",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "702bd326-edca-447a-9f9d-875636511e3d",
+                    "FilterBase": [
+                      {
+                        "Id": "12916",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b6681bba-108e-4dd7-a136-c0dce4400467",
+                          "DataColumn": [
+                            {
+                              "Id": "12918",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "742",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12916",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4172",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c7e1cb0c-aaa2-429f-a3d4-03499a261348",
+                    "FilterBase": [
+                      {
+                        "Id": "12924",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ebf34eb7-c1d3-4826-9efe-8d136d5b84b1",
+                          "DataColumn": [
+                            {
+                              "Id": "12926",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "881",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "12927",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4176",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "886eb7cc-5909-4c7e-ab04-ab06ee639a05",
+                    "FilterBase": [
+                      {
+                        "Id": "12930",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "00b6e7af-b927-4c3b-bf13-38f9a58c150f",
+                          "DataColumn": [
+                            {
+                              "Id": "12932",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "901",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "12933",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "315",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "15a054bb-f15b-4fdd-9c6a-81baee16ac29",
+                    "DataTable": "90",
+                    "FilterCollection": "4177"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "90",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "12938",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "87b298dd-105b-4021-8d8d-a3445a748d3a",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          },
+          {
+            "Id": "4412",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "5bd7e1ce-2a4b-4978-869d-8e117334fefb",
+              "Items": [
+                {
+                  "Id": "4187",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f96f1c8b-dd95-4486-b9be-8b86f561286d",
+                    "FilterBase": [
+                      {
+                        "Id": "12945",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3f8dcf44-06c4-411e-982e-4489bcc51813",
+                          "DataColumn": [
+                            {
+                              "Id": "12947",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1129",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12945",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4191",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2b8d97bb-732a-4395-9313-e441402720a8",
+                    "FilterBase": [
+                      {
+                        "Id": "12953",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "12955",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "c00b7356-960d-4be7-a4dc-5966487ae6f8",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "039bc72d-b4cf-48e6-9c55-844e932afe8f",
+                          "DataColumn": [
+                            {
+                              "Id": "12960",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1143",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4195",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3f06da27-b182-4dcc-8069-215a5f654e5d",
+                    "FilterBase": [
+                      {
+                        "Id": "12962",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "12963",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "4b1c3a7d-cb8a-4a13-a4d5-1d237367f74a",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "f11514ee-60a5-4252-afb7-c72285bd61d0",
+                          "DataColumn": [
+                            {
+                              "Id": "12966",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1161",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4199",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "758ac0e2-26d5-4cee-97e4-fed2c55b282a",
+                    "FilterBase": [
+                      {
+                        "Id": "12968",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "4dfd3b9d-ef43-42f9-8353-b2a0784a6a58",
+                          "DataColumn": [
+                            {
+                              "Id": "12970",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1175",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "12971",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4203",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "46aba225-7e44-426f-8104-d993add9c556",
+                    "FilterBase": [
+                      {
+                        "Id": "12974",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "12975",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "34152bae-ff04-41c4-8c9b-53e5a39c48fe",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "7c986d29-269c-44c5-a3a9-f6f6bae7c627",
+                          "DataColumn": [
+                            {
+                              "Id": "12978",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1189",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4207",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f6bbaf14-fcc5-473d-a963-c72bcb2c065a",
+                    "FilterBase": [
+                      {
+                        "Id": "12980",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "09ec0a0e-13f7-46a2-b721-0aedfd89a3bc",
+                          "DataColumn": [
+                            {
+                              "Id": "12982",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1203",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12980",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4211",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bae664ae-dd09-4a51-8c10-66496ea20b8c",
+                    "FilterBase": [
+                      {
+                        "Id": "12988",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a00cac53-7073-4d9a-b205-57513636162d",
+                          "DataColumn": [
+                            {
+                              "Id": "12990",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1217",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12988",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4215",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "db6f15c0-6be3-4fcf-94e2-e79069d8a356",
+                    "FilterBase": [
+                      {
+                        "Id": "12996",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3720016f-bc45-4ad6-b7ca-fad9452a8d29",
+                          "DataColumn": [
+                            {
+                              "Id": "12998",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1231",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "12996",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4219",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "33e5ccc9-e29b-4941-98fa-542d2f88d1de",
+                    "FilterBase": [
+                      {
+                        "Id": "13004",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "95c17d7b-5d16-42d4-96ae-3c9a16b65845",
+                          "DataColumn": [
+                            {
+                              "Id": "13006",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1245",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13004",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4223",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "108a805f-00d6-4461-89a5-7c638983fb57",
+                    "FilterBase": [
+                      {
+                        "Id": "13012",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "fc3ad5a0-a1b3-4809-8a83-1d875be58984",
+                          "DataColumn": [
+                            {
+                              "Id": "13014",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1259",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13012",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4227",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "49836919-f602-4eaf-b309-3330812083c0",
+                    "FilterBase": [
+                      {
+                        "Id": "13020",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "7fe75041-160e-4ca7-9972-7f523ffade86",
+                          "DataColumn": [
+                            {
+                              "Id": "13022",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1273",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13020",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4231",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4ef50b87-3121-4e18-9c63-39d0b696f142",
+                    "FilterBase": [
+                      {
+                        "Id": "13028",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1a2a4f45-610b-4f73-87f1-38cd5a2470bd",
+                          "DataColumn": [
+                            {
+                              "Id": "13030",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1287",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13028",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4235",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3b3cb05c-e157-4eac-9c8c-fa218d363033",
+                    "FilterBase": [
+                      {
+                        "Id": "13036",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "277b178e-73b0-4bfd-b73c-06342898da47",
+                          "DataColumn": [
+                            {
+                              "Id": "13038",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1301",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13036",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4239",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5b7fa25e-53f1-4fd2-a322-0496779bb8b3",
+                    "FilterBase": [
+                      {
+                        "Id": "13044",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "034c6bb8-9c98-4535-b360-98e2d5ff0202",
+                          "DataColumn": [
+                            {
+                              "Id": "13046",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1315",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13044",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4243",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bfdf92ac-7680-4a4c-a3ff-1712e3e80f41",
+                    "FilterBase": [
+                      {
+                        "Id": "13052",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2c1924bb-eb9d-4cdf-9d5d-e4457ff4a4ba",
+                          "DataColumn": [
+                            {
+                              "Id": "13054",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1329",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13052",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4247",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "867b9335-2b1f-4c99-b9ca-ffbe802f0eb7",
+                    "FilterBase": [
+                      {
+                        "Id": "13060",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f21f8d20-1bea-4831-bf08-366d5a7a5b57",
+                          "DataColumn": [
+                            {
+                              "Id": "13062",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1343",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13060",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4251",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "79f64920-206d-476a-b1f3-f1bbf8f33187",
+                    "FilterBase": [
+                      {
+                        "Id": "13068",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c483abbd-653f-4b89-8b53-ceb55ac9fd55",
+                          "DataColumn": [
+                            {
+                              "Id": "13070",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1357",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13068",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4255",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bd0f89e7-03db-4fea-ac32-c4975a28219d",
+                    "FilterBase": [
+                      {
+                        "Id": "13076",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b9faab7c-eafc-4699-ba2e-e0107120a8c9",
+                          "DataColumn": [
+                            {
+                              "Id": "13078",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1371",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13076",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4259",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e3941188-d9b2-40d7-a437-1dcb2df683d8",
+                    "FilterBase": [
+                      {
+                        "Id": "13084",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6a1d78f3-7002-481e-8edb-ccce5f61eac4",
+                          "DataColumn": [
+                            {
+                              "Id": "13086",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1385",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13084",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4263",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4d48a3f7-0068-41b6-9b81-5b5e3b85f568",
+                    "FilterBase": [
+                      {
+                        "Id": "13092",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "411c0b16-d046-4a50-90ef-c162c0df48b6",
+                          "DataColumn": [
+                            {
+                              "Id": "13094",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1399",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13092",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4267",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2777f414-2850-46e9-ab75-c1bbe7c8a289",
+                    "FilterBase": [
+                      {
+                        "Id": "13100",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c8671397-ee02-433e-8893-6e6ee753bc1e",
+                          "DataColumn": [
+                            {
+                              "Id": "13102",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1413",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13100",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4271",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c93296f1-a4ea-4fc7-b109-af884804fa92",
+                    "FilterBase": [
+                      {
+                        "Id": "13108",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "aeb50f8f-8836-4a3c-bcac-144c66a00ed2",
+                          "DataColumn": [
+                            {
+                              "Id": "13110",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1427",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13108",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4275",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d03fa6fc-2526-48b9-9028-fedb094567eb",
+                    "FilterBase": [
+                      {
+                        "Id": "13116",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b196a71b-0873-43cc-93e6-7138891436ce",
+                          "DataColumn": [
+                            {
+                              "Id": "13118",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1441",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13116",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4279",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "56b645b1-de46-4549-a7d9-2c9e2dc77a91",
+                    "FilterBase": [
+                      {
+                        "Id": "13124",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "13c4bc9b-32be-406c-b468-d30da52ea2c7",
+                          "DataColumn": [
+                            {
+                              "Id": "13126",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1455",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13124",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4283",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b0cff040-7a5a-4320-abe1-510d18955f32",
+                    "FilterBase": [
+                      {
+                        "Id": "13132",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0282beeb-ebf4-4526-b1a4-8bc8c84aa969",
+                          "DataColumn": [
+                            {
+                              "Id": "13134",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1469",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13132",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4287",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7c46cba7-4300-463a-91cb-aa7f2a3d71a5",
+                    "FilterBase": [
+                      {
+                        "Id": "13140",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "cec5a943-64b5-4996-a873-25fb1b970101",
+                          "DataColumn": [
+                            {
+                              "Id": "13142",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1483",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13140",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4291",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4a1841a2-8229-499c-9409-3d40a5dfe119",
+                    "FilterBase": [
+                      {
+                        "Id": "13148",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "012eeb61-4414-44fc-b463-034917ec5b8c",
+                          "DataColumn": [
+                            {
+                              "Id": "13150",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1497",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13148",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4295",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "05f73fb6-6b65-4ffe-a8e2-c1d5ff1fa3c9",
+                    "FilterBase": [
+                      {
+                        "Id": "13156",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "94e675a9-7d14-48ff-b954-81a37834670a",
+                          "DataColumn": [
+                            {
+                              "Id": "13158",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1511",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13156",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4299",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b98bec42-28f3-4902-9fab-933f7b176871",
+                    "FilterBase": [
+                      {
+                        "Id": "13164",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9f5ab52d-698b-46e8-a1a5-1b1ebf3e0f6c",
+                          "DataColumn": [
+                            {
+                              "Id": "13166",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1525",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13164",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4303",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9336f688-d505-4846-9393-a2c944e57d00",
+                    "FilterBase": [
+                      {
+                        "Id": "13172",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6781d39a-e0f2-42d3-adaf-7a4d5627c3cd",
+                          "DataColumn": [
+                            {
+                              "Id": "13174",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1539",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13172",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4307",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e7949ece-836b-4a8f-a695-c463615ef013",
+                    "FilterBase": [
+                      {
+                        "Id": "13180",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "533ec5f5-e703-4c95-8762-8492379f09c2",
+                          "DataColumn": [
+                            {
+                              "Id": "13182",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1553",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13180",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4311",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5ddb45b8-905a-4ba1-8fa5-11396567414f",
+                    "FilterBase": [
+                      {
+                        "Id": "13188",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "bc570075-074c-4f7f-9ce8-9b52400ffc16",
+                          "DataColumn": [
+                            {
+                              "Id": "13190",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1567",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13188",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4315",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "cc23363c-545c-4e1f-ab1b-290a59f73c54",
+                    "FilterBase": [
+                      {
+                        "Id": "13196",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "209358a4-3c5b-4ca7-89d2-0ce8ba2ab0c2",
+                          "DataColumn": [
+                            {
+                              "Id": "13198",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1581",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13196",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4319",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "da2e6b5f-aa22-4954-ae0a-8d4d650427b1",
+                    "FilterBase": [
+                      {
+                        "Id": "13204",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a8d1c57f-b7f2-49db-8afa-47fab2b78af2",
+                          "DataColumn": [
+                            {
+                              "Id": "13206",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1595",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13204",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4323",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e6472f47-a671-455c-912f-09b346c8c53d",
+                    "FilterBase": [
+                      {
+                        "Id": "13212",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6002145e-e335-4ccf-9d93-64a18bc301fe",
+                          "DataColumn": [
+                            {
+                              "Id": "13214",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1609",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13212",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4327",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "26964bb2-f3a1-45f2-8908-85b3cc5d2c9c",
+                    "FilterBase": [
+                      {
+                        "Id": "13220",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "4251a0c7-3a63-49c4-86cc-0244db5c6093",
+                          "DataColumn": [
+                            {
+                              "Id": "13222",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1623",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13220",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4331",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a12409ad-a8c8-4f2b-b47c-5592aad4c696",
+                    "FilterBase": [
+                      {
+                        "Id": "13228",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c7ad5758-8772-492c-b12b-e231d553f1cc",
+                          "DataColumn": [
+                            {
+                              "Id": "13230",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1637",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13228",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4335",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "323f4198-9483-4de0-9f7b-4cc307d21e65",
+                    "FilterBase": [
+                      {
+                        "Id": "13236",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "fa8889c7-9689-4ecb-bedd-1d2de126feb4",
+                          "DataColumn": [
+                            {
+                              "Id": "13238",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1651",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13236",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4339",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f8f4fe95-0080-46c0-ae24-d84155e8d90e",
+                    "FilterBase": [
+                      {
+                        "Id": "13244",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1b478e17-54a9-44c7-a313-25dd8103c593",
+                          "DataColumn": [
+                            {
+                              "Id": "13246",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1665",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13244",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4343",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c448fa98-e83c-4929-8244-ebfdcc8b8078",
+                    "FilterBase": [
+                      {
+                        "Id": "13252",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a44d9d18-3950-4825-b4c4-af197b1a98c9",
+                          "DataColumn": [
+                            {
+                              "Id": "13254",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1679",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13252",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4347",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "886489fb-ae89-4521-b92a-15c621d0eacd",
+                    "FilterBase": [
+                      {
+                        "Id": "13260",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0cc852b6-ebb5-43b0-aefe-d1ed0ced0bd0",
+                          "DataColumn": [
+                            {
+                              "Id": "13262",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1693",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13260",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4351",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a8ae74e8-d113-4fa3-b143-65d201793728",
+                    "FilterBase": [
+                      {
+                        "Id": "13268",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "613deaea-413a-4032-9cbd-fc790d93dd61",
+                          "DataColumn": [
+                            {
+                              "Id": "13270",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1707",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13268",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4355",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7727139d-41a8-4cbd-b047-df47b26d9022",
+                    "FilterBase": [
+                      {
+                        "Id": "13276",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "cc7c784c-555e-433a-8ebd-b3975eede0d9",
+                          "DataColumn": [
+                            {
+                              "Id": "13278",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1721",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13276",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4359",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c7a524f0-e0fe-4b81-9677-11e1c04e15c6",
+                    "FilterBase": [
+                      {
+                        "Id": "13284",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "26b3fbdb-8285-4bb7-821b-f6d79b889e1c",
+                          "DataColumn": [
+                            {
+                              "Id": "13286",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1735",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13284",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4363",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9264613c-c34f-4ae5-a620-dab9eef50d7b",
+                    "FilterBase": [
+                      {
+                        "Id": "13292",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a1b26e61-bd1e-4119-b622-59aaccb1f1f9",
+                          "DataColumn": [
+                            {
+                              "Id": "13294",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1749",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13292",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4367",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b2f6b1cb-fbdf-4f90-b61e-071736aab418",
+                    "FilterBase": [
+                      {
+                        "Id": "13300",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "44f7fec6-1c53-4032-a0a8-2d50faefac28",
+                          "DataColumn": [
+                            {
+                              "Id": "13302",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1763",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13300",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4371",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7760a15a-f119-4fb7-84aa-75a0c86b96c2",
+                    "FilterBase": [
+                      {
+                        "Id": "13308",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1063358a-5a0a-48df-b115-c46d2bacf90f",
+                          "DataColumn": [
+                            {
+                              "Id": "13310",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1777",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13308",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4375",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "12d46401-d4f7-4a77-a53d-55fb6165dfb0",
+                    "FilterBase": [
+                      {
+                        "Id": "13316",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c4d241b2-6be6-4f9e-9ded-b6a8a1fe0e61",
+                          "DataColumn": [
+                            {
+                              "Id": "13318",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1791",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13316",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4379",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a3b12425-0a5e-4d27-af7e-a75107f66971",
+                    "FilterBase": [
+                      {
+                        "Id": "13324",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "83056d03-0d95-4299-a053-7d9efb7ec71d",
+                          "DataColumn": [
+                            {
+                              "Id": "13326",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1805",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13324",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4383",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "26ca8cab-f4dc-40c1-920f-dbe3148f9c5d",
+                    "FilterBase": [
+                      {
+                        "Id": "13332",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3ef05ecd-a3ba-441d-9773-f223ef831e4a",
+                          "DataColumn": [
+                            {
+                              "Id": "13334",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1819",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13332",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4387",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4cdba3c6-dc7e-41d5-bfb9-4a7edafa59f9",
+                    "FilterBase": [
+                      {
+                        "Id": "13340",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b15c2c43-d57d-4b04-8bc5-6cfd1b5a4b20",
+                          "DataColumn": [
+                            {
+                              "Id": "13342",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1833",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13340",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4391",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7c7439d7-08a4-4afb-9c74-759f8669e6a7",
+                    "FilterBase": [
+                      {
+                        "Id": "13348",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "711c34bc-0d4f-4f9f-abc4-933dc8b607ee",
+                          "DataColumn": [
+                            {
+                              "Id": "13350",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1847",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13348",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4395",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ed3c154b-6fb0-42ab-975b-8138f3f600b5",
+                    "FilterBase": [
+                      {
+                        "Id": "13356",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "5bda7158-c530-4eca-9d88-870da0a21557",
+                          "DataColumn": [
+                            {
+                              "Id": "13358",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1861",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13356",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4399",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "dc06272d-c332-463f-be8b-475f06c14796",
+                    "FilterBase": [
+                      {
+                        "Id": "13364",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "79f81945-978a-456c-b119-6e069db413f0",
+                          "DataColumn": [
+                            {
+                              "Id": "13366",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1875",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13364",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4403",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3dba9d59-fe0b-42e0-8bec-717d39817d71",
+                    "FilterBase": [
+                      {
+                        "Id": "13372",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c237fb63-e326-49eb-a630-e3401e892217",
+                          "DataColumn": [
+                            {
+                              "Id": "13374",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1889",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13372",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4407",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5b3ee4e4-b66e-4a3e-9efb-66989aaf20ef",
+                    "FilterBase": [
+                      {
+                        "Id": "13380",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "decfe1d1-6cfb-4e5c-875f-e8ec7215fc0d",
+                          "DataColumn": [
+                            {
+                              "Id": "13382",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1903",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13380",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "4411",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "043e1019-87f9-42cf-b658-97e695d4b0c4",
+                    "FilterBase": [
+                      {
+                        "Id": "13388",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6359c729-c93e-4b7b-99c9-9d99af34403c",
+                          "DataColumn": [
+                            {
+                              "Id": "13390",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1917",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13388",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "318",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "3cd582ee-f109-4db4-8a07-4b69b35bece9",
+                    "DataTable": "305",
+                    "FilterCollection": "4412"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "305",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "13396",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "10f512bb-f37b-4233-b39d-93932f6fdd64",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ],
+        "DataSelection": "309",
+        "AutoConfigureFilterCollections": "true"
+      },
+      "Children": []
+    },
+    {
+      "Id": "4066",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b638efd8-562a-4418-b725-86244df9bac8",
+        "FilterBase": [
+          {
+            "Id": "12730",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "f1ce7e9a-f7b1-4f23-b12e-17e25bcb2394",
+              "DataColumn": [
+                {
+                  "Id": "12736",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "407",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "12737",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4062",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5a294557-ac43-422a-a989-6155c985e6c6",
+        "FilterBase": [
+          {
+            "Id": "12740",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "ec4969ee-3fdc-4f6b-9883-43fec1098d74",
+              "DataColumn": [
+                {
+                  "Id": "12742",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "114",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "12743",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4043",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "05ac4166-f776-49c1-8b83-577edf739d29",
+        "FilterBase": [
+          {
+            "Id": "12745",
+            "Type": "RadioButtonFilter",
+            "Fields": {
+              "DocumentNodeId": "b8c7dd86-b368-44c5-adda-4de28f2348d8",
+              "DataColumn": [
+                {
+                  "Id": "12748",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "173",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "12749",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4051",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "18911405-b5cf-4b94-aae7-89cf72fbe619",
+        "FilterBase": [
+          {
+            "Id": "12751",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d78a7fab-d763-4036-a897-aff2c8ac98f1",
+              "DataColumn": [
+                {
+                  "Id": "12754",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "527",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12751",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4047",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "af551016-9987-49c8-b708-7c8eabb5b7ac",
+        "FilterBase": [
+          {
+            "Id": "12765",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6c5c6ca5-d24a-408a-9f82-15b93f58b6cf",
+              "DataColumn": [
+                {
+                  "Id": "12767",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "563",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12765",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4108",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1b4652b3-7d5c-4bad-9e03-8e10c6dfda9c",
+        "FilterBase": [
+          {
+            "Id": "12773",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1edc85f7-8001-4429-9c7e-a7a4ddffd83f",
+              "DataColumn": [
+                {
+                  "Id": "12775",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "581",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12773",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4112",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e84f508f-cd8e-462e-aef5-95a3c258b452",
+        "FilterBase": [
+          {
+            "Id": "12781",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1476afdb-91f9-4510-bc7b-af320526fc56",
+              "DataColumn": [
+                {
+                  "Id": "12783",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "599",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12781",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4116",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0c780e34-5f64-4643-9fcb-14dc59b27596",
+        "FilterBase": [
+          {
+            "Id": "12789",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "547971ae-5e82-4796-b492-54286db155b9",
+              "DataColumn": [
+                {
+                  "Id": "12791",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "617",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12789",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4120",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e23a5850-6411-4a00-9e2e-0154b7d7ce86",
+        "FilterBase": [
+          {
+            "Id": "12797",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "10f45675-0c8f-4b9d-80b8-3a5de80242e6",
+              "DataColumn": [
+                {
+                  "Id": "12799",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "635",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12797",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4124",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ba3bffa7-6b3f-4635-b568-075c667a027f",
+        "FilterBase": [
+          {
+            "Id": "12805",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "5448e841-ca8f-43ea-aed1-3862388f6b29",
+              "DataColumn": [
+                {
+                  "Id": "12807",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "653",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12805",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4128",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "22f86b65-c74f-4fed-8620-e2eae415432b",
+        "FilterBase": [
+          {
+            "Id": "12813",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "eaaa0740-1db8-4bef-9b10-61a4f4cbaee3",
+              "DataColumn": [
+                {
+                  "Id": "12815",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "671",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12813",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4132",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f3f5a7dd-2209-48c9-baf1-3abc890c41b1",
+        "FilterBase": [
+          {
+            "Id": "12821",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3cc2a8c9-d99d-45fb-9a13-924944f131b4",
+              "DataColumn": [
+                {
+                  "Id": "12823",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "689",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12821",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4136",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c3f7bdf8-cdcb-463e-b5ec-d3d380559282",
+        "FilterBase": [
+          {
+            "Id": "12829",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "fd77374b-dc63-4a87-b34e-5c6e7685d67c",
+              "DataColumn": [
+                {
+                  "Id": "12831",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "707",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12829",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4070",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a37b847b-3b99-417a-91ce-1516eaede1b7",
+        "FilterBase": [
+          {
+            "Id": "12837",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "6db7c716-03e4-41e4-a0d8-041083b99f67",
+              "DataColumn": [
+                {
+                  "Id": "12839",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "158",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "12840",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4074",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6a3d9640-0e46-4b38-94c0-609a2e56680c",
+        "FilterBase": [
+          {
+            "Id": "12842",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "021750ef-5202-408c-9b2f-d4a8ea3bac3a",
+              "DataColumn": [
+                {
+                  "Id": "12844",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "760",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12842",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4078",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "321fea7e-a452-4b53-b0e4-0b1e80711e8a",
+        "FilterBase": [
+          {
+            "Id": "12850",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2aac32e8-2105-44e3-aa0f-d54a53d5bdc9",
+              "DataColumn": [
+                {
+                  "Id": "12852",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "782",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12850",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4082",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "69ed8f39-a5af-4ef7-bd6c-43f749591cb0",
+        "FilterBase": [
+          {
+            "Id": "12858",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2c64af67-afab-4560-8e43-cb1dd9b564af",
+              "DataColumn": [
+                {
+                  "Id": "12860",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "806",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12858",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4086",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "13d14061-6dbb-4bd2-9e21-f97e3b7e4662",
+        "FilterBase": [
+          {
+            "Id": "12866",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "72608b5c-6ca6-4aa9-a600-ad5687ab4f2d",
+              "DataColumn": [
+                {
+                  "Id": "12868",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "828",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12866",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4140",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "51945bbe-963e-482a-a3ec-3b437919e820",
+        "FilterBase": [
+          {
+            "Id": "12874",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "ca71466d-732d-4770-a9e5-e797762079a7",
+              "DataColumn": [
+                {
+                  "Id": "12876",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "846",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12874",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4097",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "dbf0ba9a-c372-4b7f-95c6-90ee0b2aa1b1",
+        "FilterBase": [
+          {
+            "Id": "12882",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "8886b0d9-712b-4966-a852-437583bfa8be",
+              "DataColumn": [
+                {
+                  "Id": "12885",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "247",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "12886",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4152",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6684b17d-1fcc-4cf4-ace5-0f9f4cbaa125",
+        "FilterBase": [
+          {
+            "Id": "12890",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "77b8262a-aa26-448c-9bb7-73fa30601ca3",
+              "DataColumn": [
+                {
+                  "Id": "12892",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "357",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12890",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4156",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2ec69f66-6078-4ee5-9058-612ae7c67138",
+        "FilterBase": [
+          {
+            "Id": "12898",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "a42e3004-fdaf-40dc-83b0-34bcbc36dd3e",
+              "DataColumn": [
+                {
+                  "Id": "12900",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "262",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "12901",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4160",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "fd963f51-45a8-4d74-b057-eccb84da4113",
+        "FilterBase": [
+          {
+            "Id": "12903",
+            "Type": "RadioButtonFilter",
+            "Fields": {
+              "DocumentNodeId": "8b0d2789-1cdb-4aeb-8734-e540041855b3",
+              "DataColumn": [
+                {
+                  "Id": "12905",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "505",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "12906",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4164",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3e3842e3-819b-4967-bdaf-b7695c730d4d",
+        "FilterBase": [
+          {
+            "Id": "12908",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9f3e54e7-a740-4f6f-be42-1ce217af54d1",
+              "DataColumn": [
+                {
+                  "Id": "12910",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "545",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12908",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4168",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "702bd326-edca-447a-9f9d-875636511e3d",
+        "FilterBase": [
+          {
+            "Id": "12916",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "b6681bba-108e-4dd7-a136-c0dce4400467",
+              "DataColumn": [
+                {
+                  "Id": "12918",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "742",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12916",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4172",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c7e1cb0c-aaa2-429f-a3d4-03499a261348",
+        "FilterBase": [
+          {
+            "Id": "12924",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "ebf34eb7-c1d3-4826-9efe-8d136d5b84b1",
+              "DataColumn": [
+                {
+                  "Id": "12926",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "881",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "12927",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4176",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "886eb7cc-5909-4c7e-ab04-ab06ee639a05",
+        "FilterBase": [
+          {
+            "Id": "12930",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "00b6e7af-b927-4c3b-bf13-38f9a58c150f",
+              "DataColumn": [
+                {
+                  "Id": "12932",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "901",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "12933",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4187",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f96f1c8b-dd95-4486-b9be-8b86f561286d",
+        "FilterBase": [
+          {
+            "Id": "12945",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3f8dcf44-06c4-411e-982e-4489bcc51813",
+              "DataColumn": [
+                {
+                  "Id": "12947",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1129",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12945",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4191",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2b8d97bb-732a-4395-9313-e441402720a8",
+        "FilterBase": [
+          {
+            "Id": "12953",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "12955",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "c00b7356-960d-4be7-a4dc-5966487ae6f8",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "039bc72d-b4cf-48e6-9c55-844e932afe8f",
+              "DataColumn": [
+                {
+                  "Id": "12960",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1143",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4195",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3f06da27-b182-4dcc-8069-215a5f654e5d",
+        "FilterBase": [
+          {
+            "Id": "12962",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "12963",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "4b1c3a7d-cb8a-4a13-a4d5-1d237367f74a",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "f11514ee-60a5-4252-afb7-c72285bd61d0",
+              "DataColumn": [
+                {
+                  "Id": "12966",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1161",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4199",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "758ac0e2-26d5-4cee-97e4-fed2c55b282a",
+        "FilterBase": [
+          {
+            "Id": "12968",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "4dfd3b9d-ef43-42f9-8353-b2a0784a6a58",
+              "DataColumn": [
+                {
+                  "Id": "12970",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1175",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "12971",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4203",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "46aba225-7e44-426f-8104-d993add9c556",
+        "FilterBase": [
+          {
+            "Id": "12974",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "12975",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "34152bae-ff04-41c4-8c9b-53e5a39c48fe",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "7c986d29-269c-44c5-a3a9-f6f6bae7c627",
+              "DataColumn": [
+                {
+                  "Id": "12978",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1189",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4207",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f6bbaf14-fcc5-473d-a963-c72bcb2c065a",
+        "FilterBase": [
+          {
+            "Id": "12980",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "09ec0a0e-13f7-46a2-b721-0aedfd89a3bc",
+              "DataColumn": [
+                {
+                  "Id": "12982",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1203",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12980",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4211",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bae664ae-dd09-4a51-8c10-66496ea20b8c",
+        "FilterBase": [
+          {
+            "Id": "12988",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "a00cac53-7073-4d9a-b205-57513636162d",
+              "DataColumn": [
+                {
+                  "Id": "12990",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1217",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12988",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4215",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "db6f15c0-6be3-4fcf-94e2-e79069d8a356",
+        "FilterBase": [
+          {
+            "Id": "12996",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3720016f-bc45-4ad6-b7ca-fad9452a8d29",
+              "DataColumn": [
+                {
+                  "Id": "12998",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1231",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "12996",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4219",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "33e5ccc9-e29b-4941-98fa-542d2f88d1de",
+        "FilterBase": [
+          {
+            "Id": "13004",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "95c17d7b-5d16-42d4-96ae-3c9a16b65845",
+              "DataColumn": [
+                {
+                  "Id": "13006",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1245",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13004",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4223",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "108a805f-00d6-4461-89a5-7c638983fb57",
+        "FilterBase": [
+          {
+            "Id": "13012",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "fc3ad5a0-a1b3-4809-8a83-1d875be58984",
+              "DataColumn": [
+                {
+                  "Id": "13014",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1259",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13012",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4227",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "49836919-f602-4eaf-b309-3330812083c0",
+        "FilterBase": [
+          {
+            "Id": "13020",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "7fe75041-160e-4ca7-9972-7f523ffade86",
+              "DataColumn": [
+                {
+                  "Id": "13022",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1273",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13020",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4231",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4ef50b87-3121-4e18-9c63-39d0b696f142",
+        "FilterBase": [
+          {
+            "Id": "13028",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1a2a4f45-610b-4f73-87f1-38cd5a2470bd",
+              "DataColumn": [
+                {
+                  "Id": "13030",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1287",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13028",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4235",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3b3cb05c-e157-4eac-9c8c-fa218d363033",
+        "FilterBase": [
+          {
+            "Id": "13036",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "277b178e-73b0-4bfd-b73c-06342898da47",
+              "DataColumn": [
+                {
+                  "Id": "13038",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1301",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13036",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4239",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5b7fa25e-53f1-4fd2-a322-0496779bb8b3",
+        "FilterBase": [
+          {
+            "Id": "13044",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "034c6bb8-9c98-4535-b360-98e2d5ff0202",
+              "DataColumn": [
+                {
+                  "Id": "13046",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1315",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13044",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4243",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bfdf92ac-7680-4a4c-a3ff-1712e3e80f41",
+        "FilterBase": [
+          {
+            "Id": "13052",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2c1924bb-eb9d-4cdf-9d5d-e4457ff4a4ba",
+              "DataColumn": [
+                {
+                  "Id": "13054",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1329",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13052",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4247",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "867b9335-2b1f-4c99-b9ca-ffbe802f0eb7",
+        "FilterBase": [
+          {
+            "Id": "13060",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "f21f8d20-1bea-4831-bf08-366d5a7a5b57",
+              "DataColumn": [
+                {
+                  "Id": "13062",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1343",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13060",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4251",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "79f64920-206d-476a-b1f3-f1bbf8f33187",
+        "FilterBase": [
+          {
+            "Id": "13068",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c483abbd-653f-4b89-8b53-ceb55ac9fd55",
+              "DataColumn": [
+                {
+                  "Id": "13070",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1357",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13068",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4255",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bd0f89e7-03db-4fea-ac32-c4975a28219d",
+        "FilterBase": [
+          {
+            "Id": "13076",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "b9faab7c-eafc-4699-ba2e-e0107120a8c9",
+              "DataColumn": [
+                {
+                  "Id": "13078",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1371",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13076",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4259",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e3941188-d9b2-40d7-a437-1dcb2df683d8",
+        "FilterBase": [
+          {
+            "Id": "13084",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6a1d78f3-7002-481e-8edb-ccce5f61eac4",
+              "DataColumn": [
+                {
+                  "Id": "13086",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1385",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13084",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4263",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4d48a3f7-0068-41b6-9b81-5b5e3b85f568",
+        "FilterBase": [
+          {
+            "Id": "13092",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "411c0b16-d046-4a50-90ef-c162c0df48b6",
+              "DataColumn": [
+                {
+                  "Id": "13094",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1399",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13092",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4267",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2777f414-2850-46e9-ab75-c1bbe7c8a289",
+        "FilterBase": [
+          {
+            "Id": "13100",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c8671397-ee02-433e-8893-6e6ee753bc1e",
+              "DataColumn": [
+                {
+                  "Id": "13102",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1413",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13100",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4271",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c93296f1-a4ea-4fc7-b109-af884804fa92",
+        "FilterBase": [
+          {
+            "Id": "13108",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "aeb50f8f-8836-4a3c-bcac-144c66a00ed2",
+              "DataColumn": [
+                {
+                  "Id": "13110",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1427",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13108",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4275",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d03fa6fc-2526-48b9-9028-fedb094567eb",
+        "FilterBase": [
+          {
+            "Id": "13116",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "b196a71b-0873-43cc-93e6-7138891436ce",
+              "DataColumn": [
+                {
+                  "Id": "13118",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1441",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13116",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4279",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "56b645b1-de46-4549-a7d9-2c9e2dc77a91",
+        "FilterBase": [
+          {
+            "Id": "13124",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "13c4bc9b-32be-406c-b468-d30da52ea2c7",
+              "DataColumn": [
+                {
+                  "Id": "13126",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1455",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13124",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4283",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b0cff040-7a5a-4320-abe1-510d18955f32",
+        "FilterBase": [
+          {
+            "Id": "13132",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0282beeb-ebf4-4526-b1a4-8bc8c84aa969",
+              "DataColumn": [
+                {
+                  "Id": "13134",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1469",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13132",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4287",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7c46cba7-4300-463a-91cb-aa7f2a3d71a5",
+        "FilterBase": [
+          {
+            "Id": "13140",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "cec5a943-64b5-4996-a873-25fb1b970101",
+              "DataColumn": [
+                {
+                  "Id": "13142",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1483",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13140",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4291",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4a1841a2-8229-499c-9409-3d40a5dfe119",
+        "FilterBase": [
+          {
+            "Id": "13148",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "012eeb61-4414-44fc-b463-034917ec5b8c",
+              "DataColumn": [
+                {
+                  "Id": "13150",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1497",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13148",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4295",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "05f73fb6-6b65-4ffe-a8e2-c1d5ff1fa3c9",
+        "FilterBase": [
+          {
+            "Id": "13156",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "94e675a9-7d14-48ff-b954-81a37834670a",
+              "DataColumn": [
+                {
+                  "Id": "13158",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1511",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13156",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4299",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b98bec42-28f3-4902-9fab-933f7b176871",
+        "FilterBase": [
+          {
+            "Id": "13164",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9f5ab52d-698b-46e8-a1a5-1b1ebf3e0f6c",
+              "DataColumn": [
+                {
+                  "Id": "13166",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1525",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13164",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4303",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9336f688-d505-4846-9393-a2c944e57d00",
+        "FilterBase": [
+          {
+            "Id": "13172",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6781d39a-e0f2-42d3-adaf-7a4d5627c3cd",
+              "DataColumn": [
+                {
+                  "Id": "13174",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1539",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13172",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4307",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e7949ece-836b-4a8f-a695-c463615ef013",
+        "FilterBase": [
+          {
+            "Id": "13180",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "533ec5f5-e703-4c95-8762-8492379f09c2",
+              "DataColumn": [
+                {
+                  "Id": "13182",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1553",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13180",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4311",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5ddb45b8-905a-4ba1-8fa5-11396567414f",
+        "FilterBase": [
+          {
+            "Id": "13188",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "bc570075-074c-4f7f-9ce8-9b52400ffc16",
+              "DataColumn": [
+                {
+                  "Id": "13190",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1567",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13188",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4315",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "cc23363c-545c-4e1f-ab1b-290a59f73c54",
+        "FilterBase": [
+          {
+            "Id": "13196",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "209358a4-3c5b-4ca7-89d2-0ce8ba2ab0c2",
+              "DataColumn": [
+                {
+                  "Id": "13198",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1581",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13196",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4319",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "da2e6b5f-aa22-4954-ae0a-8d4d650427b1",
+        "FilterBase": [
+          {
+            "Id": "13204",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "a8d1c57f-b7f2-49db-8afa-47fab2b78af2",
+              "DataColumn": [
+                {
+                  "Id": "13206",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1595",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13204",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4323",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e6472f47-a671-455c-912f-09b346c8c53d",
+        "FilterBase": [
+          {
+            "Id": "13212",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6002145e-e335-4ccf-9d93-64a18bc301fe",
+              "DataColumn": [
+                {
+                  "Id": "13214",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1609",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13212",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4327",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "26964bb2-f3a1-45f2-8908-85b3cc5d2c9c",
+        "FilterBase": [
+          {
+            "Id": "13220",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "4251a0c7-3a63-49c4-86cc-0244db5c6093",
+              "DataColumn": [
+                {
+                  "Id": "13222",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1623",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13220",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4331",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a12409ad-a8c8-4f2b-b47c-5592aad4c696",
+        "FilterBase": [
+          {
+            "Id": "13228",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c7ad5758-8772-492c-b12b-e231d553f1cc",
+              "DataColumn": [
+                {
+                  "Id": "13230",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1637",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13228",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4335",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "323f4198-9483-4de0-9f7b-4cc307d21e65",
+        "FilterBase": [
+          {
+            "Id": "13236",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "fa8889c7-9689-4ecb-bedd-1d2de126feb4",
+              "DataColumn": [
+                {
+                  "Id": "13238",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1651",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13236",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4339",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f8f4fe95-0080-46c0-ae24-d84155e8d90e",
+        "FilterBase": [
+          {
+            "Id": "13244",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1b478e17-54a9-44c7-a313-25dd8103c593",
+              "DataColumn": [
+                {
+                  "Id": "13246",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1665",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13244",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4343",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c448fa98-e83c-4929-8244-ebfdcc8b8078",
+        "FilterBase": [
+          {
+            "Id": "13252",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "a44d9d18-3950-4825-b4c4-af197b1a98c9",
+              "DataColumn": [
+                {
+                  "Id": "13254",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1679",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13252",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4347",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "886489fb-ae89-4521-b92a-15c621d0eacd",
+        "FilterBase": [
+          {
+            "Id": "13260",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0cc852b6-ebb5-43b0-aefe-d1ed0ced0bd0",
+              "DataColumn": [
+                {
+                  "Id": "13262",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1693",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13260",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4351",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a8ae74e8-d113-4fa3-b143-65d201793728",
+        "FilterBase": [
+          {
+            "Id": "13268",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "613deaea-413a-4032-9cbd-fc790d93dd61",
+              "DataColumn": [
+                {
+                  "Id": "13270",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1707",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13268",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4355",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7727139d-41a8-4cbd-b047-df47b26d9022",
+        "FilterBase": [
+          {
+            "Id": "13276",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "cc7c784c-555e-433a-8ebd-b3975eede0d9",
+              "DataColumn": [
+                {
+                  "Id": "13278",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1721",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13276",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4359",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c7a524f0-e0fe-4b81-9677-11e1c04e15c6",
+        "FilterBase": [
+          {
+            "Id": "13284",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "26b3fbdb-8285-4bb7-821b-f6d79b889e1c",
+              "DataColumn": [
+                {
+                  "Id": "13286",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1735",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13284",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4363",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9264613c-c34f-4ae5-a620-dab9eef50d7b",
+        "FilterBase": [
+          {
+            "Id": "13292",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "a1b26e61-bd1e-4119-b622-59aaccb1f1f9",
+              "DataColumn": [
+                {
+                  "Id": "13294",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1749",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13292",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4367",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b2f6b1cb-fbdf-4f90-b61e-071736aab418",
+        "FilterBase": [
+          {
+            "Id": "13300",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "44f7fec6-1c53-4032-a0a8-2d50faefac28",
+              "DataColumn": [
+                {
+                  "Id": "13302",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1763",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13300",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4371",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7760a15a-f119-4fb7-84aa-75a0c86b96c2",
+        "FilterBase": [
+          {
+            "Id": "13308",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1063358a-5a0a-48df-b115-c46d2bacf90f",
+              "DataColumn": [
+                {
+                  "Id": "13310",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1777",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13308",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4375",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "12d46401-d4f7-4a77-a53d-55fb6165dfb0",
+        "FilterBase": [
+          {
+            "Id": "13316",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c4d241b2-6be6-4f9e-9ded-b6a8a1fe0e61",
+              "DataColumn": [
+                {
+                  "Id": "13318",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1791",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13316",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4379",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a3b12425-0a5e-4d27-af7e-a75107f66971",
+        "FilterBase": [
+          {
+            "Id": "13324",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "83056d03-0d95-4299-a053-7d9efb7ec71d",
+              "DataColumn": [
+                {
+                  "Id": "13326",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1805",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13324",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4383",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "26ca8cab-f4dc-40c1-920f-dbe3148f9c5d",
+        "FilterBase": [
+          {
+            "Id": "13332",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3ef05ecd-a3ba-441d-9773-f223ef831e4a",
+              "DataColumn": [
+                {
+                  "Id": "13334",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1819",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13332",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4387",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4cdba3c6-dc7e-41d5-bfb9-4a7edafa59f9",
+        "FilterBase": [
+          {
+            "Id": "13340",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "b15c2c43-d57d-4b04-8bc5-6cfd1b5a4b20",
+              "DataColumn": [
+                {
+                  "Id": "13342",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1833",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13340",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4391",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7c7439d7-08a4-4afb-9c74-759f8669e6a7",
+        "FilterBase": [
+          {
+            "Id": "13348",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "711c34bc-0d4f-4f9f-abc4-933dc8b607ee",
+              "DataColumn": [
+                {
+                  "Id": "13350",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1847",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13348",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4395",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ed3c154b-6fb0-42ab-975b-8138f3f600b5",
+        "FilterBase": [
+          {
+            "Id": "13356",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "5bda7158-c530-4eca-9d88-870da0a21557",
+              "DataColumn": [
+                {
+                  "Id": "13358",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1861",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13356",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4399",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "dc06272d-c332-463f-be8b-475f06c14796",
+        "FilterBase": [
+          {
+            "Id": "13364",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "79f81945-978a-456c-b119-6e069db413f0",
+              "DataColumn": [
+                {
+                  "Id": "13366",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1875",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13364",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4403",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3dba9d59-fe0b-42e0-8bec-717d39817d71",
+        "FilterBase": [
+          {
+            "Id": "13372",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c237fb63-e326-49eb-a630-e3401e892217",
+              "DataColumn": [
+                {
+                  "Id": "13374",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1889",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13372",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4407",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5b3ee4e4-b66e-4a3e-9efb-66989aaf20ef",
+        "FilterBase": [
+          {
+            "Id": "13380",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "decfe1d1-6cfb-4e5c-875f-e8ec7215fc0d",
+              "DataColumn": [
+                {
+                  "Id": "13382",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1903",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13380",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "4411",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "043e1019-87f9-42cf-b658-97e695d4b0c4",
+        "FilterBase": [
+          {
+            "Id": "13388",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6359c729-c93e-4b7b-99c9-9d99af34403c",
+              "DataColumn": [
+                {
+                  "Id": "13390",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1917",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13388",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8569",
+      "Type": "FilteringScheme",
+      "Fields": {
+        "DocumentNodeId": "138073d5-7172-41fc-81a3-5222be81af43",
+        "Items": [
+          {
+            "Id": "8714",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "505689a7-b161-4270-9a64-4c092eceebb4",
+              "Items": [
+                {
+                  "Id": "8596",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e953bf1b-eac5-4db9-bdb2-1e022686f9f6",
+                    "FilterBase": [
+                      {
+                        "Id": "13404",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c15d53f6-2248-46ab-b38a-2d620406cd00",
+                          "DataColumn": [
+                            {
+                              "Id": "13406",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "407",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "13407",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8592",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f68e499a-6fcb-4bad-b49f-be1f90c5c245",
+                    "FilterBase": [
+                      {
+                        "Id": "13409",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "243634d2-0f60-4ccf-b8ad-edc5ede45a4a",
+                          "DataColumn": [
+                            {
+                              "Id": "13411",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "114",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "13412",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8588",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b512cca0-8f81-4b90-ac46-812d2bc1d6f9",
+                    "FilterBase": [
+                      {
+                        "Id": "13414",
+                        "Type": "RadioButtonFilter",
+                        "Fields": {
+                          "DocumentNodeId": "73fd58d8-9543-4e6e-89b1-07b6bb0d1a78",
+                          "DataColumn": [
+                            {
+                              "Id": "13416",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "173",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "13417",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8626",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "066fff77-f836-47d3-9eaf-fd923c71359f",
+                    "FilterBase": [
+                      {
+                        "Id": "13419",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d12b90c8-c37e-4464-9452-cf5ec7625576",
+                          "DataColumn": [
+                            {
+                              "Id": "13421",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "527",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13419",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8661",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3f3487f1-a08f-4ad3-9b1b-90f61a29962d",
+                    "FilterBase": [
+                      {
+                        "Id": "13427",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c309aa40-198e-4b48-a286-fc36a43af686",
+                          "DataColumn": [
+                            {
+                              "Id": "13429",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "563",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13427",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8665",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ddd99ff3-53e9-42f6-8813-b8f04315ab80",
+                    "FilterBase": [
+                      {
+                        "Id": "13435",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b42e21f0-8900-4d28-bb74-cdffd059276d",
+                          "DataColumn": [
+                            {
+                              "Id": "13437",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "581",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13435",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8669",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "227b13de-1495-41e5-91b3-981b74380b92",
+                    "FilterBase": [
+                      {
+                        "Id": "13443",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1850cf98-a16a-466d-80c9-ff9834643b80",
+                          "DataColumn": [
+                            {
+                              "Id": "13445",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "599",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13443",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8673",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "40b558d4-dd62-40cd-aab2-c1949c5d9075",
+                    "FilterBase": [
+                      {
+                        "Id": "13451",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2785157d-822f-4759-98ca-e6cb1adc5282",
+                          "DataColumn": [
+                            {
+                              "Id": "13453",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "617",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13451",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8677",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0f9f5a67-f719-4c2d-a067-22167f47b251",
+                    "FilterBase": [
+                      {
+                        "Id": "13459",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "373b3d43-9864-432d-afeb-acdc53b2839b",
+                          "DataColumn": [
+                            {
+                              "Id": "13461",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "635",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13459",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8681",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "86f5d8fb-83c7-4d2b-8b82-fbf16108ee10",
+                    "FilterBase": [
+                      {
+                        "Id": "13467",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "bc272b47-dbaa-49f0-b17a-93a874d53935",
+                          "DataColumn": [
+                            {
+                              "Id": "13469",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "653",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13467",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8685",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "08e2c2f4-31c7-4ad4-9246-770b6e0f8e91",
+                    "FilterBase": [
+                      {
+                        "Id": "13475",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "28a39421-04f9-40cc-9812-90fc8df2d5b3",
+                          "DataColumn": [
+                            {
+                              "Id": "13477",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "671",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13475",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8689",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8a9043e8-7112-4e3b-871a-6ed9dde8db44",
+                    "FilterBase": [
+                      {
+                        "Id": "13483",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "bb736a35-dac1-45c0-9a0f-f4199e256a39",
+                          "DataColumn": [
+                            {
+                              "Id": "13485",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "689",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13483",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8693",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bf74b84a-551e-4617-b2e3-41639c00ffd7",
+                    "FilterBase": [
+                      {
+                        "Id": "13491",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "de473a1b-2db1-4a71-ac26-ce7295b5e2b1",
+                          "DataColumn": [
+                            {
+                              "Id": "13493",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "707",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13491",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8600",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "20543af6-8fb9-4495-b1e1-249924844974",
+                    "FilterBase": [
+                      {
+                        "Id": "13499",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "51b0d38b-808b-4954-b02b-e39917626ee7",
+                          "DataColumn": [
+                            {
+                              "Id": "13501",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "158",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "13502",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8604",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "48f658ac-0bff-4412-a8cd-45f662206dd4",
+                    "FilterBase": [
+                      {
+                        "Id": "13504",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "4ef4d7b3-19eb-488f-8073-ebba8a18eb57",
+                          "DataColumn": [
+                            {
+                              "Id": "13506",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "760",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13504",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8608",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a5e61c8a-818c-4ee2-bc3b-d607f729b670",
+                    "FilterBase": [
+                      {
+                        "Id": "13512",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d76fc53e-6968-4b85-a57d-fafae60f79f6",
+                          "DataColumn": [
+                            {
+                              "Id": "13514",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "782",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13512",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8612",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6f310032-d50c-4b5f-a0b1-b6e8ff291fa8",
+                    "FilterBase": [
+                      {
+                        "Id": "13520",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f8ce10e7-acd5-40c3-8eca-a2ec1650e795",
+                          "DataColumn": [
+                            {
+                              "Id": "13522",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "806",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13520",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8616",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "afd4a38a-5844-412b-b0a7-f320be271fa7",
+                    "FilterBase": [
+                      {
+                        "Id": "13528",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "be85e10e-6734-4e4e-9c58-1c8be63ce6b7",
+                          "DataColumn": [
+                            {
+                              "Id": "13530",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "828",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13528",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8697",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9df01d66-9c29-4be5-bf49-4bb0ff8ea6aa",
+                    "FilterBase": [
+                      {
+                        "Id": "13536",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "22fe5320-d687-4f7e-b56e-8b6e4289b2ae",
+                          "DataColumn": [
+                            {
+                              "Id": "13538",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "846",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13536",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8646",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8ac14d47-4ffc-4205-81ed-b11d133ee10a",
+                    "FilterBase": [
+                      {
+                        "Id": "13544",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1d045d08-3cc8-4f6c-89a4-71f2150590ed",
+                          "DataColumn": [
+                            {
+                              "Id": "13546",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "247",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "13547",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8638",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "401578e3-6d24-4bd1-b5ec-ec7146e371ff",
+                    "FilterBase": [
+                      {
+                        "Id": "13550",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "348484ff-fe7f-4e5a-a7c0-7de047121044",
+                          "DataColumn": [
+                            {
+                              "Id": "13552",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "357",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13550",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8642",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "36eadb9e-df0c-4804-aba4-275ed75e1d97",
+                    "FilterBase": [
+                      {
+                        "Id": "13558",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "4541c074-18d5-4351-9078-3597990473fb",
+                          "DataColumn": [
+                            {
+                              "Id": "13560",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "262",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "13561",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8634",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bd0f088e-02d0-4688-a283-4f36d54c8653",
+                    "FilterBase": [
+                      {
+                        "Id": "13563",
+                        "Type": "RadioButtonFilter",
+                        "Fields": {
+                          "DocumentNodeId": "75670149-ae5f-46a8-86fb-64b3109f3113",
+                          "DataColumn": [
+                            {
+                              "Id": "13565",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "505",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "13566",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8657",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "610db79e-7561-409a-9ed3-d5b9536755c1",
+                    "FilterBase": [
+                      {
+                        "Id": "13568",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "e93a10c7-22f7-4dff-b610-832dd8ee3914",
+                          "DataColumn": [
+                            {
+                              "Id": "13570",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "545",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13568",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8630",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "58555b96-fca5-4009-a76d-a8deef5d5dfd",
+                    "FilterBase": [
+                      {
+                        "Id": "13576",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "deb1fd01-483c-4a03-970e-991752e277e2",
+                          "DataColumn": [
+                            {
+                              "Id": "13578",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "742",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13576",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8709",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "21edca09-edec-4e09-9ed8-c0db9faddac4",
+                    "FilterBase": [
+                      {
+                        "Id": "13584",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "685c227d-49bd-4854-98fd-7a04be5c62a0",
+                          "DataColumn": [
+                            {
+                              "Id": "13586",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "881",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "13587",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8713",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ef594e26-2c24-4eec-a68a-c823ace32b40",
+                    "FilterBase": [
+                      {
+                        "Id": "13590",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c24e5f99-1ea9-4a69-bd67-82a685eca2d2",
+                          "DataColumn": [
+                            {
+                              "Id": "13592",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "901",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "13593",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "326",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "70278b91-2d3f-4833-b87b-77444a505bb8",
+                    "DataTable": "90",
+                    "FilterCollection": "8714"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "90",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "13596",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "622dcbda-bce2-458f-b434-11a032dd9fb0",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          },
+          {
+            "Id": "8949",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "a4f63256-e003-4dc7-96dd-99dfccb0f51a",
+              "Items": [
+                {
+                  "Id": "8724",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a94d311e-3179-4fe6-8c88-044921a0a626",
+                    "FilterBase": [
+                      {
+                        "Id": "13602",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f742bab0-9a5b-473c-be25-502be40b540f",
+                          "DataColumn": [
+                            {
+                              "Id": "13604",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1129",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13602",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8728",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3c0fe510-1de3-4e39-87ff-5d895c67a166",
+                    "FilterBase": [
+                      {
+                        "Id": "13610",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "13611",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "65af07e5-c4c2-42fa-a993-d2cd49858b3c",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "b7cafd02-731d-48cc-bb64-14319171e8b0",
+                          "DataColumn": [
+                            {
+                              "Id": "13614",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1143",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8732",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8d934c81-5a31-4b2e-900a-45a96dc0150a",
+                    "FilterBase": [
+                      {
+                        "Id": "13616",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "13617",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "39667c76-37c5-48c0-8922-bc468f81b4b4",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "823ced1f-1587-4ef0-8379-9f4f052ff176",
+                          "DataColumn": [
+                            {
+                              "Id": "13620",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1161",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8736",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "83c03086-fffb-4174-9416-29f5416ce188",
+                    "FilterBase": [
+                      {
+                        "Id": "13622",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "70e34b47-3b89-41d2-a925-ecf7d47d79ae",
+                          "DataColumn": [
+                            {
+                              "Id": "13624",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1175",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "13625",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8740",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "933e76aa-3e7b-4a71-8057-ac04bc03ac6d",
+                    "FilterBase": [
+                      {
+                        "Id": "13628",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "13629",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "749b1cb4-ad89-4437-ba9a-690fbc531f55",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "88b41d0f-ef9b-441d-9b93-fc75a039f6d2",
+                          "DataColumn": [
+                            {
+                              "Id": "13632",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1189",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8744",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "46866391-8638-406e-9e31-e5678b09f342",
+                    "FilterBase": [
+                      {
+                        "Id": "13634",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ab52bf11-a2f7-4fd4-948e-810a2acae4ab",
+                          "DataColumn": [
+                            {
+                              "Id": "13636",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1203",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13634",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8748",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "affc0cd3-b9a7-4ba8-9a38-655e71a298db",
+                    "FilterBase": [
+                      {
+                        "Id": "13642",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9cef19c4-fced-466e-bb56-e030e232d5da",
+                          "DataColumn": [
+                            {
+                              "Id": "13644",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1217",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13642",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8752",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2b9efd1b-de39-4d9e-bd7b-698d492be491",
+                    "FilterBase": [
+                      {
+                        "Id": "13650",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c7d9090b-3694-4a24-8539-29525f9e19e2",
+                          "DataColumn": [
+                            {
+                              "Id": "13652",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1231",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13650",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8756",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "37e443b2-5ae9-439e-93a4-6ddda79288b4",
+                    "FilterBase": [
+                      {
+                        "Id": "13658",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "66d4c016-17f0-4c01-b9a8-8028b38b1271",
+                          "DataColumn": [
+                            {
+                              "Id": "13660",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1245",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13658",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8760",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "66a64c8e-8512-4a7a-9565-5f9ee908836c",
+                    "FilterBase": [
+                      {
+                        "Id": "13666",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ed372311-8c48-420c-98e3-d04169325aed",
+                          "DataColumn": [
+                            {
+                              "Id": "13668",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1259",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13666",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8764",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1ab0be57-c1af-4d44-8995-9aab8e753da9",
+                    "FilterBase": [
+                      {
+                        "Id": "13674",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9434283a-7ee9-4e33-8dba-2a5da8ef835f",
+                          "DataColumn": [
+                            {
+                              "Id": "13676",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1273",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13674",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8768",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8794d80e-1b66-4be1-b8cb-f26c5037027c",
+                    "FilterBase": [
+                      {
+                        "Id": "13682",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6ec6b5d4-1188-40c9-bb04-76d48559c97e",
+                          "DataColumn": [
+                            {
+                              "Id": "13684",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1287",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13682",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8772",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "793a4b1b-9f48-4157-bb51-305f147b4764",
+                    "FilterBase": [
+                      {
+                        "Id": "13690",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1a42d416-34aa-4e34-9575-245d8963ff32",
+                          "DataColumn": [
+                            {
+                              "Id": "13692",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1301",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13690",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8776",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e206e88f-8094-4d89-a714-2891a4e0fd24",
+                    "FilterBase": [
+                      {
+                        "Id": "13698",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c5a929b9-b073-4a30-a61b-1545baadb987",
+                          "DataColumn": [
+                            {
+                              "Id": "13700",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1315",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13698",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8780",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f54a3475-69ae-467d-9695-08dab88369eb",
+                    "FilterBase": [
+                      {
+                        "Id": "13706",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6eb48c0c-02f1-414e-b19e-96b55dc5b222",
+                          "DataColumn": [
+                            {
+                              "Id": "13708",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1329",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13706",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8784",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ed34a7f6-cd72-4130-807b-89ff2498b14c",
+                    "FilterBase": [
+                      {
+                        "Id": "13714",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9dbccc5c-0124-43cd-bda4-b90a776ca4d9",
+                          "DataColumn": [
+                            {
+                              "Id": "13716",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1343",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13714",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8788",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "143e1675-be9e-427c-8c6b-265105e0445b",
+                    "FilterBase": [
+                      {
+                        "Id": "13722",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "928e9dbf-9adb-41cc-8242-04d8b118daf7",
+                          "DataColumn": [
+                            {
+                              "Id": "13724",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1357",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13722",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8792",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3bc4c621-e6f2-46d9-9b55-e75dfda495c4",
+                    "FilterBase": [
+                      {
+                        "Id": "13730",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0160f8fc-fd5f-4dc4-89e4-0ecd6b73ad7e",
+                          "DataColumn": [
+                            {
+                              "Id": "13732",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1371",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13730",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8796",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d117f919-566b-44dd-8b1c-3c2d8c7a60a8",
+                    "FilterBase": [
+                      {
+                        "Id": "13738",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a1a77fec-abba-48d5-83d4-4cb70782f028",
+                          "DataColumn": [
+                            {
+                              "Id": "13740",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1385",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13738",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8800",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6357a0dc-616f-4e85-bf46-4a8a459d645b",
+                    "FilterBase": [
+                      {
+                        "Id": "13746",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "38bb2ecf-c3e4-4fb9-a835-95183c030aac",
+                          "DataColumn": [
+                            {
+                              "Id": "13748",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1399",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13746",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8804",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ea4e565b-b219-4151-a1e3-d9a3acf58097",
+                    "FilterBase": [
+                      {
+                        "Id": "13754",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d88d1a86-f880-48f6-9afa-42555d4f1c8d",
+                          "DataColumn": [
+                            {
+                              "Id": "13756",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1413",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13754",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8808",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "cabf138e-f4a5-41c3-8cae-9752ff78b5d6",
+                    "FilterBase": [
+                      {
+                        "Id": "13762",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "60cece80-d3cf-40a3-8e0c-7815d28f9a78",
+                          "DataColumn": [
+                            {
+                              "Id": "13764",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1427",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13762",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8812",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c2a0d773-ed85-48c8-80b5-0c6b0621583e",
+                    "FilterBase": [
+                      {
+                        "Id": "13770",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2ea67a8a-7a50-4c80-96eb-cec047800552",
+                          "DataColumn": [
+                            {
+                              "Id": "13772",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1441",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13770",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8816",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "629c2042-65e2-439f-a73d-70bc4e8e93eb",
+                    "FilterBase": [
+                      {
+                        "Id": "13778",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "edc3aa8a-1e46-4a96-8572-cca6083dca1d",
+                          "DataColumn": [
+                            {
+                              "Id": "13780",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1455",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13778",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8820",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2c39164a-6659-4a3f-8991-c3f1e9144293",
+                    "FilterBase": [
+                      {
+                        "Id": "13786",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "bebfad36-3cdf-4d78-b491-2466673434c9",
+                          "DataColumn": [
+                            {
+                              "Id": "13788",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1469",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13786",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8824",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5643ccea-aeac-4736-b3b7-6e8341750785",
+                    "FilterBase": [
+                      {
+                        "Id": "13794",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1c9f226f-0522-4f80-8059-2b7890d64cb3",
+                          "DataColumn": [
+                            {
+                              "Id": "13796",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1483",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13794",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8828",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "cbd8d6c5-389f-47b5-8761-d49cde729394",
+                    "FilterBase": [
+                      {
+                        "Id": "13802",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "dac989f4-b6cd-49fc-87b8-8cd9d6f2a4dd",
+                          "DataColumn": [
+                            {
+                              "Id": "13804",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1497",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13802",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8832",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "68a5c5fd-342f-4a2c-a1dd-5763de97687e",
+                    "FilterBase": [
+                      {
+                        "Id": "13810",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "02c273f5-2964-47fe-a1fd-01b2eeb84f23",
+                          "DataColumn": [
+                            {
+                              "Id": "13812",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1511",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13810",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8836",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e0f3594f-21e3-4432-adcf-1d3eb75d2e24",
+                    "FilterBase": [
+                      {
+                        "Id": "13818",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "63000195-adc1-4da7-babe-3d35d188b987",
+                          "DataColumn": [
+                            {
+                              "Id": "13820",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1525",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13818",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8840",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "932730c7-10f8-4f9a-8ab2-c0fc0c605f06",
+                    "FilterBase": [
+                      {
+                        "Id": "13826",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2dec521b-345f-460b-9c3f-95839d2318fa",
+                          "DataColumn": [
+                            {
+                              "Id": "13828",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1539",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13826",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8844",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5cd8a8ab-8146-4899-b7fb-659b505d9904",
+                    "FilterBase": [
+                      {
+                        "Id": "13834",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "856c15fb-974b-43bf-bf7d-e8b072ee124d",
+                          "DataColumn": [
+                            {
+                              "Id": "13836",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1553",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13834",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8848",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "03412464-8466-4a55-b070-c6b97358ef05",
+                    "FilterBase": [
+                      {
+                        "Id": "13842",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2f132acc-3ef0-4bec-8100-6cf67ffda001",
+                          "DataColumn": [
+                            {
+                              "Id": "13844",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1567",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13842",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8852",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b8077539-f412-414d-b558-b8a75d769aaf",
+                    "FilterBase": [
+                      {
+                        "Id": "13850",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ed65121f-d222-444a-a6ce-5924bd7d990e",
+                          "DataColumn": [
+                            {
+                              "Id": "13852",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1581",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13850",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8856",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c568f8b7-47cd-41bd-87ac-40ed0c4896dc",
+                    "FilterBase": [
+                      {
+                        "Id": "13858",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "39eccf3a-b4c7-4f0f-bfbd-46539f64d158",
+                          "DataColumn": [
+                            {
+                              "Id": "13860",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1595",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13858",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8860",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "303375ff-7836-4602-a380-5708e60ef1b9",
+                    "FilterBase": [
+                      {
+                        "Id": "13866",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "565237e9-1602-4565-a0b5-ac9edd5c8f62",
+                          "DataColumn": [
+                            {
+                              "Id": "13868",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1609",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13866",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8864",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "287a4d9d-5988-4dbf-a4d7-ebaeb2f27108",
+                    "FilterBase": [
+                      {
+                        "Id": "13874",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a6aafbd1-c9ab-45ed-ad8d-0e687fa98b4a",
+                          "DataColumn": [
+                            {
+                              "Id": "13876",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1623",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13874",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8868",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "14b73ef9-b109-4b1e-bdd9-d486f61ce6bc",
+                    "FilterBase": [
+                      {
+                        "Id": "13882",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8b74438f-3e4f-4904-b56f-cebe7f02950c",
+                          "DataColumn": [
+                            {
+                              "Id": "13884",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1637",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13882",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8872",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b0498b99-33a4-40ce-88c8-a486b60265e6",
+                    "FilterBase": [
+                      {
+                        "Id": "13890",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c91e0710-82b7-49af-a087-e1a6ab1794f5",
+                          "DataColumn": [
+                            {
+                              "Id": "13892",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1651",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13890",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8876",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c0943f56-6344-486f-b854-bb07b3338d91",
+                    "FilterBase": [
+                      {
+                        "Id": "13898",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d19fd6ac-95c2-4bf5-8c94-b6f5395947ac",
+                          "DataColumn": [
+                            {
+                              "Id": "13900",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1665",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13898",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8880",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9eed5f99-6f6b-409c-a329-5aadcd146015",
+                    "FilterBase": [
+                      {
+                        "Id": "13906",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "86a8f164-44e2-4063-a29f-ce2e10140a42",
+                          "DataColumn": [
+                            {
+                              "Id": "13908",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1679",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13906",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8884",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "87328fce-27e5-4779-8812-f34868721b96",
+                    "FilterBase": [
+                      {
+                        "Id": "13914",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "39f10eb5-f871-47d6-98c0-643d6135210d",
+                          "DataColumn": [
+                            {
+                              "Id": "13916",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1693",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13914",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8888",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f293ac3f-2b68-4d7a-9caf-5ea8fef36436",
+                    "FilterBase": [
+                      {
+                        "Id": "13922",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "5a0aaeb6-489e-44b9-b37c-4056d65f57e1",
+                          "DataColumn": [
+                            {
+                              "Id": "13924",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1707",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13922",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8892",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bac20d10-2d7c-448c-98d7-f2bfba13ffb1",
+                    "FilterBase": [
+                      {
+                        "Id": "13930",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3eb66249-8aa9-4e3c-8172-d9b211e2ebce",
+                          "DataColumn": [
+                            {
+                              "Id": "13932",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1721",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13930",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8896",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b16c3741-6c4d-4ccb-9ec8-f2ba3e763d73",
+                    "FilterBase": [
+                      {
+                        "Id": "13938",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6a38998e-fd16-4abb-86c3-99cb9a1425c6",
+                          "DataColumn": [
+                            {
+                              "Id": "13940",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1735",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13938",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8900",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ee70a234-2195-4879-823c-8f2eebe675ee",
+                    "FilterBase": [
+                      {
+                        "Id": "13946",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "00348b11-c082-44eb-89f3-4d0763075353",
+                          "DataColumn": [
+                            {
+                              "Id": "13948",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1749",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13946",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8904",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e61b480e-06b7-44f1-8591-246fac22d408",
+                    "FilterBase": [
+                      {
+                        "Id": "13954",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1926afc5-6890-4438-b9e7-cdd87ff886aa",
+                          "DataColumn": [
+                            {
+                              "Id": "13956",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1763",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13954",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8908",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d5a19c5d-2769-4486-85cd-23799197256e",
+                    "FilterBase": [
+                      {
+                        "Id": "13962",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "46b5c2ff-424d-40c3-84f5-45f2a762055e",
+                          "DataColumn": [
+                            {
+                              "Id": "13964",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1777",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13962",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8912",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d2247ce3-8033-45d7-a3eb-307ef7f76849",
+                    "FilterBase": [
+                      {
+                        "Id": "13970",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "24f09fd5-3fab-4111-8738-8147df44664f",
+                          "DataColumn": [
+                            {
+                              "Id": "13972",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1791",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13970",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8916",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "29a24f4f-caec-495b-a473-79b484c6df93",
+                    "FilterBase": [
+                      {
+                        "Id": "13978",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8df2f455-10ef-4aae-9c20-cfb61a4e6d36",
+                          "DataColumn": [
+                            {
+                              "Id": "13980",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1805",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13978",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8920",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "00759a4d-f10d-4daa-8694-ec80fbf4688f",
+                    "FilterBase": [
+                      {
+                        "Id": "13986",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c0738c2f-2e11-4b52-8200-2a1711d44b9b",
+                          "DataColumn": [
+                            {
+                              "Id": "13988",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1819",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13986",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8924",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8f17dba6-35be-406c-be54-768d1cccf72f",
+                    "FilterBase": [
+                      {
+                        "Id": "13994",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "483d87c5-5420-49db-9e09-9a066e82a248",
+                          "DataColumn": [
+                            {
+                              "Id": "13996",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1833",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "13994",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8928",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "39eb8a2c-fd62-4a4d-bd13-3e817d09f961",
+                    "FilterBase": [
+                      {
+                        "Id": "14002",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f9ea9eae-eea6-4836-bab9-02d52f7fd633",
+                          "DataColumn": [
+                            {
+                              "Id": "14004",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1847",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14002",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8932",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "288b3634-9e2f-4274-95b6-e5344739e187",
+                    "FilterBase": [
+                      {
+                        "Id": "14010",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "db4437f5-13fc-436c-b16a-160913cb9705",
+                          "DataColumn": [
+                            {
+                              "Id": "14012",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1861",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14010",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8936",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bcc33978-ec54-478b-9fed-1a766e9ce70f",
+                    "FilterBase": [
+                      {
+                        "Id": "14018",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2f5d2db6-3d1f-4866-8954-88d0b8984e40",
+                          "DataColumn": [
+                            {
+                              "Id": "14020",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1875",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14018",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8940",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c188f28b-301f-466c-9a4c-f21bad44583e",
+                    "FilterBase": [
+                      {
+                        "Id": "14026",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9f86671d-99c1-4e1e-babe-286962ed5981",
+                          "DataColumn": [
+                            {
+                              "Id": "14028",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1889",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14026",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8944",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f06b6b24-df47-4090-9bee-cfe8c4e00ef2",
+                    "FilterBase": [
+                      {
+                        "Id": "14034",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "16aef56e-60f5-41e3-9741-94985909417d",
+                          "DataColumn": [
+                            {
+                              "Id": "14036",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1903",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14034",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "8948",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "47018e20-3b8a-4f9a-9f1f-ef8b95903e05",
+                    "FilterBase": [
+                      {
+                        "Id": "14042",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "4e47bd65-de33-4792-a2d8-750a2af98446",
+                          "DataColumn": [
+                            {
+                              "Id": "14044",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1917",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14042",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "329",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "6df6cc19-7c7f-4544-9d7f-23f335d45dfb",
+                    "DataTable": "305",
+                    "FilterCollection": "8949"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "305",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "14050",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "e3099449-0be9-4c2a-a5aa-92fcc966c77c",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ],
+        "DataSelection": "320",
+        "AutoConfigureFilterCollections": "true"
+      },
+      "Children": []
+    },
+    {
+      "Id": "8596",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e953bf1b-eac5-4db9-bdb2-1e022686f9f6",
+        "FilterBase": [
+          {
+            "Id": "13404",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "c15d53f6-2248-46ab-b38a-2d620406cd00",
+              "DataColumn": [
+                {
+                  "Id": "13406",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "407",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "13407",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8592",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f68e499a-6fcb-4bad-b49f-be1f90c5c245",
+        "FilterBase": [
+          {
+            "Id": "13409",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "243634d2-0f60-4ccf-b8ad-edc5ede45a4a",
+              "DataColumn": [
+                {
+                  "Id": "13411",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "114",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "13412",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8588",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b512cca0-8f81-4b90-ac46-812d2bc1d6f9",
+        "FilterBase": [
+          {
+            "Id": "13414",
+            "Type": "RadioButtonFilter",
+            "Fields": {
+              "DocumentNodeId": "73fd58d8-9543-4e6e-89b1-07b6bb0d1a78",
+              "DataColumn": [
+                {
+                  "Id": "13416",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "173",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "13417",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8626",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "066fff77-f836-47d3-9eaf-fd923c71359f",
+        "FilterBase": [
+          {
+            "Id": "13419",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d12b90c8-c37e-4464-9452-cf5ec7625576",
+              "DataColumn": [
+                {
+                  "Id": "13421",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "527",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13419",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8661",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3f3487f1-a08f-4ad3-9b1b-90f61a29962d",
+        "FilterBase": [
+          {
+            "Id": "13427",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c309aa40-198e-4b48-a286-fc36a43af686",
+              "DataColumn": [
+                {
+                  "Id": "13429",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "563",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13427",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8665",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ddd99ff3-53e9-42f6-8813-b8f04315ab80",
+        "FilterBase": [
+          {
+            "Id": "13435",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "b42e21f0-8900-4d28-bb74-cdffd059276d",
+              "DataColumn": [
+                {
+                  "Id": "13437",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "581",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13435",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8669",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "227b13de-1495-41e5-91b3-981b74380b92",
+        "FilterBase": [
+          {
+            "Id": "13443",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1850cf98-a16a-466d-80c9-ff9834643b80",
+              "DataColumn": [
+                {
+                  "Id": "13445",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "599",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13443",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8673",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "40b558d4-dd62-40cd-aab2-c1949c5d9075",
+        "FilterBase": [
+          {
+            "Id": "13451",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2785157d-822f-4759-98ca-e6cb1adc5282",
+              "DataColumn": [
+                {
+                  "Id": "13453",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "617",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13451",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8677",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0f9f5a67-f719-4c2d-a067-22167f47b251",
+        "FilterBase": [
+          {
+            "Id": "13459",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "373b3d43-9864-432d-afeb-acdc53b2839b",
+              "DataColumn": [
+                {
+                  "Id": "13461",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "635",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13459",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8681",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "86f5d8fb-83c7-4d2b-8b82-fbf16108ee10",
+        "FilterBase": [
+          {
+            "Id": "13467",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "bc272b47-dbaa-49f0-b17a-93a874d53935",
+              "DataColumn": [
+                {
+                  "Id": "13469",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "653",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13467",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8685",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "08e2c2f4-31c7-4ad4-9246-770b6e0f8e91",
+        "FilterBase": [
+          {
+            "Id": "13475",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "28a39421-04f9-40cc-9812-90fc8df2d5b3",
+              "DataColumn": [
+                {
+                  "Id": "13477",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "671",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13475",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8689",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8a9043e8-7112-4e3b-871a-6ed9dde8db44",
+        "FilterBase": [
+          {
+            "Id": "13483",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "bb736a35-dac1-45c0-9a0f-f4199e256a39",
+              "DataColumn": [
+                {
+                  "Id": "13485",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "689",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13483",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8693",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bf74b84a-551e-4617-b2e3-41639c00ffd7",
+        "FilterBase": [
+          {
+            "Id": "13491",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "de473a1b-2db1-4a71-ac26-ce7295b5e2b1",
+              "DataColumn": [
+                {
+                  "Id": "13493",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "707",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13491",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8600",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "20543af6-8fb9-4495-b1e1-249924844974",
+        "FilterBase": [
+          {
+            "Id": "13499",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "51b0d38b-808b-4954-b02b-e39917626ee7",
+              "DataColumn": [
+                {
+                  "Id": "13501",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "158",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "13502",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8604",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "48f658ac-0bff-4412-a8cd-45f662206dd4",
+        "FilterBase": [
+          {
+            "Id": "13504",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "4ef4d7b3-19eb-488f-8073-ebba8a18eb57",
+              "DataColumn": [
+                {
+                  "Id": "13506",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "760",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13504",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8608",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a5e61c8a-818c-4ee2-bc3b-d607f729b670",
+        "FilterBase": [
+          {
+            "Id": "13512",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d76fc53e-6968-4b85-a57d-fafae60f79f6",
+              "DataColumn": [
+                {
+                  "Id": "13514",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "782",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13512",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8612",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6f310032-d50c-4b5f-a0b1-b6e8ff291fa8",
+        "FilterBase": [
+          {
+            "Id": "13520",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "f8ce10e7-acd5-40c3-8eca-a2ec1650e795",
+              "DataColumn": [
+                {
+                  "Id": "13522",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "806",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13520",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8616",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "afd4a38a-5844-412b-b0a7-f320be271fa7",
+        "FilterBase": [
+          {
+            "Id": "13528",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "be85e10e-6734-4e4e-9c58-1c8be63ce6b7",
+              "DataColumn": [
+                {
+                  "Id": "13530",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "828",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13528",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8697",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9df01d66-9c29-4be5-bf49-4bb0ff8ea6aa",
+        "FilterBase": [
+          {
+            "Id": "13536",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "22fe5320-d687-4f7e-b56e-8b6e4289b2ae",
+              "DataColumn": [
+                {
+                  "Id": "13538",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "846",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13536",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8646",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8ac14d47-4ffc-4205-81ed-b11d133ee10a",
+        "FilterBase": [
+          {
+            "Id": "13544",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "1d045d08-3cc8-4f6c-89a4-71f2150590ed",
+              "DataColumn": [
+                {
+                  "Id": "13546",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "247",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "13547",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8638",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "401578e3-6d24-4bd1-b5ec-ec7146e371ff",
+        "FilterBase": [
+          {
+            "Id": "13550",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "348484ff-fe7f-4e5a-a7c0-7de047121044",
+              "DataColumn": [
+                {
+                  "Id": "13552",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "357",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13550",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8642",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "36eadb9e-df0c-4804-aba4-275ed75e1d97",
+        "FilterBase": [
+          {
+            "Id": "13558",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "4541c074-18d5-4351-9078-3597990473fb",
+              "DataColumn": [
+                {
+                  "Id": "13560",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "262",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "13561",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8634",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bd0f088e-02d0-4688-a283-4f36d54c8653",
+        "FilterBase": [
+          {
+            "Id": "13563",
+            "Type": "RadioButtonFilter",
+            "Fields": {
+              "DocumentNodeId": "75670149-ae5f-46a8-86fb-64b3109f3113",
+              "DataColumn": [
+                {
+                  "Id": "13565",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "505",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "13566",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8657",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "610db79e-7561-409a-9ed3-d5b9536755c1",
+        "FilterBase": [
+          {
+            "Id": "13568",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "e93a10c7-22f7-4dff-b610-832dd8ee3914",
+              "DataColumn": [
+                {
+                  "Id": "13570",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "545",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13568",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8630",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "58555b96-fca5-4009-a76d-a8deef5d5dfd",
+        "FilterBase": [
+          {
+            "Id": "13576",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "deb1fd01-483c-4a03-970e-991752e277e2",
+              "DataColumn": [
+                {
+                  "Id": "13578",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "742",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13576",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8709",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "21edca09-edec-4e09-9ed8-c0db9faddac4",
+        "FilterBase": [
+          {
+            "Id": "13584",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "685c227d-49bd-4854-98fd-7a04be5c62a0",
+              "DataColumn": [
+                {
+                  "Id": "13586",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "881",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "13587",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8713",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ef594e26-2c24-4eec-a68a-c823ace32b40",
+        "FilterBase": [
+          {
+            "Id": "13590",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "c24e5f99-1ea9-4a69-bd67-82a685eca2d2",
+              "DataColumn": [
+                {
+                  "Id": "13592",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "901",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "13593",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8724",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a94d311e-3179-4fe6-8c88-044921a0a626",
+        "FilterBase": [
+          {
+            "Id": "13602",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "f742bab0-9a5b-473c-be25-502be40b540f",
+              "DataColumn": [
+                {
+                  "Id": "13604",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1129",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13602",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8728",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3c0fe510-1de3-4e39-87ff-5d895c67a166",
+        "FilterBase": [
+          {
+            "Id": "13610",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "13611",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "65af07e5-c4c2-42fa-a993-d2cd49858b3c",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "b7cafd02-731d-48cc-bb64-14319171e8b0",
+              "DataColumn": [
+                {
+                  "Id": "13614",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1143",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8732",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8d934c81-5a31-4b2e-900a-45a96dc0150a",
+        "FilterBase": [
+          {
+            "Id": "13616",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "13617",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "39667c76-37c5-48c0-8922-bc468f81b4b4",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "823ced1f-1587-4ef0-8379-9f4f052ff176",
+              "DataColumn": [
+                {
+                  "Id": "13620",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1161",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8736",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "83c03086-fffb-4174-9416-29f5416ce188",
+        "FilterBase": [
+          {
+            "Id": "13622",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "70e34b47-3b89-41d2-a925-ecf7d47d79ae",
+              "DataColumn": [
+                {
+                  "Id": "13624",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1175",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "13625",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8740",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "933e76aa-3e7b-4a71-8057-ac04bc03ac6d",
+        "FilterBase": [
+          {
+            "Id": "13628",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "13629",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "749b1cb4-ad89-4437-ba9a-690fbc531f55",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "88b41d0f-ef9b-441d-9b93-fc75a039f6d2",
+              "DataColumn": [
+                {
+                  "Id": "13632",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1189",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8744",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "46866391-8638-406e-9e31-e5678b09f342",
+        "FilterBase": [
+          {
+            "Id": "13634",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "ab52bf11-a2f7-4fd4-948e-810a2acae4ab",
+              "DataColumn": [
+                {
+                  "Id": "13636",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1203",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13634",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8748",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "affc0cd3-b9a7-4ba8-9a38-655e71a298db",
+        "FilterBase": [
+          {
+            "Id": "13642",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9cef19c4-fced-466e-bb56-e030e232d5da",
+              "DataColumn": [
+                {
+                  "Id": "13644",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1217",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13642",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8752",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2b9efd1b-de39-4d9e-bd7b-698d492be491",
+        "FilterBase": [
+          {
+            "Id": "13650",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c7d9090b-3694-4a24-8539-29525f9e19e2",
+              "DataColumn": [
+                {
+                  "Id": "13652",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1231",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13650",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8756",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "37e443b2-5ae9-439e-93a4-6ddda79288b4",
+        "FilterBase": [
+          {
+            "Id": "13658",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "66d4c016-17f0-4c01-b9a8-8028b38b1271",
+              "DataColumn": [
+                {
+                  "Id": "13660",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1245",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13658",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8760",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "66a64c8e-8512-4a7a-9565-5f9ee908836c",
+        "FilterBase": [
+          {
+            "Id": "13666",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "ed372311-8c48-420c-98e3-d04169325aed",
+              "DataColumn": [
+                {
+                  "Id": "13668",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1259",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13666",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8764",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1ab0be57-c1af-4d44-8995-9aab8e753da9",
+        "FilterBase": [
+          {
+            "Id": "13674",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9434283a-7ee9-4e33-8dba-2a5da8ef835f",
+              "DataColumn": [
+                {
+                  "Id": "13676",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1273",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13674",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8768",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8794d80e-1b66-4be1-b8cb-f26c5037027c",
+        "FilterBase": [
+          {
+            "Id": "13682",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6ec6b5d4-1188-40c9-bb04-76d48559c97e",
+              "DataColumn": [
+                {
+                  "Id": "13684",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1287",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13682",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8772",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "793a4b1b-9f48-4157-bb51-305f147b4764",
+        "FilterBase": [
+          {
+            "Id": "13690",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1a42d416-34aa-4e34-9575-245d8963ff32",
+              "DataColumn": [
+                {
+                  "Id": "13692",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1301",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13690",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8776",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e206e88f-8094-4d89-a714-2891a4e0fd24",
+        "FilterBase": [
+          {
+            "Id": "13698",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c5a929b9-b073-4a30-a61b-1545baadb987",
+              "DataColumn": [
+                {
+                  "Id": "13700",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1315",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13698",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8780",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f54a3475-69ae-467d-9695-08dab88369eb",
+        "FilterBase": [
+          {
+            "Id": "13706",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6eb48c0c-02f1-414e-b19e-96b55dc5b222",
+              "DataColumn": [
+                {
+                  "Id": "13708",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1329",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13706",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8784",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ed34a7f6-cd72-4130-807b-89ff2498b14c",
+        "FilterBase": [
+          {
+            "Id": "13714",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9dbccc5c-0124-43cd-bda4-b90a776ca4d9",
+              "DataColumn": [
+                {
+                  "Id": "13716",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1343",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13714",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8788",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "143e1675-be9e-427c-8c6b-265105e0445b",
+        "FilterBase": [
+          {
+            "Id": "13722",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "928e9dbf-9adb-41cc-8242-04d8b118daf7",
+              "DataColumn": [
+                {
+                  "Id": "13724",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1357",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13722",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8792",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3bc4c621-e6f2-46d9-9b55-e75dfda495c4",
+        "FilterBase": [
+          {
+            "Id": "13730",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0160f8fc-fd5f-4dc4-89e4-0ecd6b73ad7e",
+              "DataColumn": [
+                {
+                  "Id": "13732",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1371",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13730",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8796",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d117f919-566b-44dd-8b1c-3c2d8c7a60a8",
+        "FilterBase": [
+          {
+            "Id": "13738",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "a1a77fec-abba-48d5-83d4-4cb70782f028",
+              "DataColumn": [
+                {
+                  "Id": "13740",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1385",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13738",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8800",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6357a0dc-616f-4e85-bf46-4a8a459d645b",
+        "FilterBase": [
+          {
+            "Id": "13746",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "38bb2ecf-c3e4-4fb9-a835-95183c030aac",
+              "DataColumn": [
+                {
+                  "Id": "13748",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1399",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13746",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8804",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ea4e565b-b219-4151-a1e3-d9a3acf58097",
+        "FilterBase": [
+          {
+            "Id": "13754",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d88d1a86-f880-48f6-9afa-42555d4f1c8d",
+              "DataColumn": [
+                {
+                  "Id": "13756",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1413",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13754",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8808",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "cabf138e-f4a5-41c3-8cae-9752ff78b5d6",
+        "FilterBase": [
+          {
+            "Id": "13762",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "60cece80-d3cf-40a3-8e0c-7815d28f9a78",
+              "DataColumn": [
+                {
+                  "Id": "13764",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1427",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13762",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8812",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c2a0d773-ed85-48c8-80b5-0c6b0621583e",
+        "FilterBase": [
+          {
+            "Id": "13770",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2ea67a8a-7a50-4c80-96eb-cec047800552",
+              "DataColumn": [
+                {
+                  "Id": "13772",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1441",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13770",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8816",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "629c2042-65e2-439f-a73d-70bc4e8e93eb",
+        "FilterBase": [
+          {
+            "Id": "13778",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "edc3aa8a-1e46-4a96-8572-cca6083dca1d",
+              "DataColumn": [
+                {
+                  "Id": "13780",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1455",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13778",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8820",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2c39164a-6659-4a3f-8991-c3f1e9144293",
+        "FilterBase": [
+          {
+            "Id": "13786",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "bebfad36-3cdf-4d78-b491-2466673434c9",
+              "DataColumn": [
+                {
+                  "Id": "13788",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1469",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13786",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8824",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5643ccea-aeac-4736-b3b7-6e8341750785",
+        "FilterBase": [
+          {
+            "Id": "13794",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1c9f226f-0522-4f80-8059-2b7890d64cb3",
+              "DataColumn": [
+                {
+                  "Id": "13796",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1483",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13794",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8828",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "cbd8d6c5-389f-47b5-8761-d49cde729394",
+        "FilterBase": [
+          {
+            "Id": "13802",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "dac989f4-b6cd-49fc-87b8-8cd9d6f2a4dd",
+              "DataColumn": [
+                {
+                  "Id": "13804",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1497",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13802",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8832",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "68a5c5fd-342f-4a2c-a1dd-5763de97687e",
+        "FilterBase": [
+          {
+            "Id": "13810",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "02c273f5-2964-47fe-a1fd-01b2eeb84f23",
+              "DataColumn": [
+                {
+                  "Id": "13812",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1511",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13810",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8836",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e0f3594f-21e3-4432-adcf-1d3eb75d2e24",
+        "FilterBase": [
+          {
+            "Id": "13818",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "63000195-adc1-4da7-babe-3d35d188b987",
+              "DataColumn": [
+                {
+                  "Id": "13820",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1525",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13818",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8840",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "932730c7-10f8-4f9a-8ab2-c0fc0c605f06",
+        "FilterBase": [
+          {
+            "Id": "13826",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2dec521b-345f-460b-9c3f-95839d2318fa",
+              "DataColumn": [
+                {
+                  "Id": "13828",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1539",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13826",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8844",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5cd8a8ab-8146-4899-b7fb-659b505d9904",
+        "FilterBase": [
+          {
+            "Id": "13834",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "856c15fb-974b-43bf-bf7d-e8b072ee124d",
+              "DataColumn": [
+                {
+                  "Id": "13836",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1553",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13834",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8848",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "03412464-8466-4a55-b070-c6b97358ef05",
+        "FilterBase": [
+          {
+            "Id": "13842",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2f132acc-3ef0-4bec-8100-6cf67ffda001",
+              "DataColumn": [
+                {
+                  "Id": "13844",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1567",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13842",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8852",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b8077539-f412-414d-b558-b8a75d769aaf",
+        "FilterBase": [
+          {
+            "Id": "13850",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "ed65121f-d222-444a-a6ce-5924bd7d990e",
+              "DataColumn": [
+                {
+                  "Id": "13852",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1581",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13850",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8856",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c568f8b7-47cd-41bd-87ac-40ed0c4896dc",
+        "FilterBase": [
+          {
+            "Id": "13858",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "39eccf3a-b4c7-4f0f-bfbd-46539f64d158",
+              "DataColumn": [
+                {
+                  "Id": "13860",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1595",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13858",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8860",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "303375ff-7836-4602-a380-5708e60ef1b9",
+        "FilterBase": [
+          {
+            "Id": "13866",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "565237e9-1602-4565-a0b5-ac9edd5c8f62",
+              "DataColumn": [
+                {
+                  "Id": "13868",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1609",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13866",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8864",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "287a4d9d-5988-4dbf-a4d7-ebaeb2f27108",
+        "FilterBase": [
+          {
+            "Id": "13874",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "a6aafbd1-c9ab-45ed-ad8d-0e687fa98b4a",
+              "DataColumn": [
+                {
+                  "Id": "13876",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1623",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13874",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8868",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "14b73ef9-b109-4b1e-bdd9-d486f61ce6bc",
+        "FilterBase": [
+          {
+            "Id": "13882",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "8b74438f-3e4f-4904-b56f-cebe7f02950c",
+              "DataColumn": [
+                {
+                  "Id": "13884",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1637",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13882",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8872",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b0498b99-33a4-40ce-88c8-a486b60265e6",
+        "FilterBase": [
+          {
+            "Id": "13890",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c91e0710-82b7-49af-a087-e1a6ab1794f5",
+              "DataColumn": [
+                {
+                  "Id": "13892",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1651",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13890",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8876",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c0943f56-6344-486f-b854-bb07b3338d91",
+        "FilterBase": [
+          {
+            "Id": "13898",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d19fd6ac-95c2-4bf5-8c94-b6f5395947ac",
+              "DataColumn": [
+                {
+                  "Id": "13900",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1665",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13898",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8880",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9eed5f99-6f6b-409c-a329-5aadcd146015",
+        "FilterBase": [
+          {
+            "Id": "13906",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "86a8f164-44e2-4063-a29f-ce2e10140a42",
+              "DataColumn": [
+                {
+                  "Id": "13908",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1679",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13906",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8884",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "87328fce-27e5-4779-8812-f34868721b96",
+        "FilterBase": [
+          {
+            "Id": "13914",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "39f10eb5-f871-47d6-98c0-643d6135210d",
+              "DataColumn": [
+                {
+                  "Id": "13916",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1693",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13914",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8888",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f293ac3f-2b68-4d7a-9caf-5ea8fef36436",
+        "FilterBase": [
+          {
+            "Id": "13922",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "5a0aaeb6-489e-44b9-b37c-4056d65f57e1",
+              "DataColumn": [
+                {
+                  "Id": "13924",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1707",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13922",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8892",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bac20d10-2d7c-448c-98d7-f2bfba13ffb1",
+        "FilterBase": [
+          {
+            "Id": "13930",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3eb66249-8aa9-4e3c-8172-d9b211e2ebce",
+              "DataColumn": [
+                {
+                  "Id": "13932",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1721",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13930",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8896",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b16c3741-6c4d-4ccb-9ec8-f2ba3e763d73",
+        "FilterBase": [
+          {
+            "Id": "13938",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6a38998e-fd16-4abb-86c3-99cb9a1425c6",
+              "DataColumn": [
+                {
+                  "Id": "13940",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1735",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13938",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8900",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ee70a234-2195-4879-823c-8f2eebe675ee",
+        "FilterBase": [
+          {
+            "Id": "13946",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "00348b11-c082-44eb-89f3-4d0763075353",
+              "DataColumn": [
+                {
+                  "Id": "13948",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1749",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13946",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8904",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e61b480e-06b7-44f1-8591-246fac22d408",
+        "FilterBase": [
+          {
+            "Id": "13954",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1926afc5-6890-4438-b9e7-cdd87ff886aa",
+              "DataColumn": [
+                {
+                  "Id": "13956",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1763",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13954",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8908",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d5a19c5d-2769-4486-85cd-23799197256e",
+        "FilterBase": [
+          {
+            "Id": "13962",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "46b5c2ff-424d-40c3-84f5-45f2a762055e",
+              "DataColumn": [
+                {
+                  "Id": "13964",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1777",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13962",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8912",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d2247ce3-8033-45d7-a3eb-307ef7f76849",
+        "FilterBase": [
+          {
+            "Id": "13970",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "24f09fd5-3fab-4111-8738-8147df44664f",
+              "DataColumn": [
+                {
+                  "Id": "13972",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1791",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13970",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8916",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "29a24f4f-caec-495b-a473-79b484c6df93",
+        "FilterBase": [
+          {
+            "Id": "13978",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "8df2f455-10ef-4aae-9c20-cfb61a4e6d36",
+              "DataColumn": [
+                {
+                  "Id": "13980",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1805",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13978",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8920",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "00759a4d-f10d-4daa-8694-ec80fbf4688f",
+        "FilterBase": [
+          {
+            "Id": "13986",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c0738c2f-2e11-4b52-8200-2a1711d44b9b",
+              "DataColumn": [
+                {
+                  "Id": "13988",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1819",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13986",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8924",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8f17dba6-35be-406c-be54-768d1cccf72f",
+        "FilterBase": [
+          {
+            "Id": "13994",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "483d87c5-5420-49db-9e09-9a066e82a248",
+              "DataColumn": [
+                {
+                  "Id": "13996",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1833",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "13994",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8928",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "39eb8a2c-fd62-4a4d-bd13-3e817d09f961",
+        "FilterBase": [
+          {
+            "Id": "14002",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "f9ea9eae-eea6-4836-bab9-02d52f7fd633",
+              "DataColumn": [
+                {
+                  "Id": "14004",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1847",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14002",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8932",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "288b3634-9e2f-4274-95b6-e5344739e187",
+        "FilterBase": [
+          {
+            "Id": "14010",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "db4437f5-13fc-436c-b16a-160913cb9705",
+              "DataColumn": [
+                {
+                  "Id": "14012",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1861",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14010",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8936",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bcc33978-ec54-478b-9fed-1a766e9ce70f",
+        "FilterBase": [
+          {
+            "Id": "14018",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2f5d2db6-3d1f-4866-8954-88d0b8984e40",
+              "DataColumn": [
+                {
+                  "Id": "14020",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1875",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14018",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8940",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c188f28b-301f-466c-9a4c-f21bad44583e",
+        "FilterBase": [
+          {
+            "Id": "14026",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9f86671d-99c1-4e1e-babe-286962ed5981",
+              "DataColumn": [
+                {
+                  "Id": "14028",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1889",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14026",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8944",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f06b6b24-df47-4090-9bee-cfe8c4e00ef2",
+        "FilterBase": [
+          {
+            "Id": "14034",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "16aef56e-60f5-41e3-9741-94985909417d",
+              "DataColumn": [
+                {
+                  "Id": "14036",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1903",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14034",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "8948",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "47018e20-3b8a-4f9a-9f1f-ef8b95903e05",
+        "FilterBase": [
+          {
+            "Id": "14042",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "4e47bd65-de33-4792-a2d8-750a2af98446",
+              "DataColumn": [
+                {
+                  "Id": "14044",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1917",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14042",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3485",
+      "Type": "FilteringScheme",
+      "Fields": {
+        "DocumentNodeId": "4c60debd-3eef-4a99-a501-92fb19f9e016",
+        "Items": [
+          {
+            "Id": "3615",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "5161fc0c-1d68-4129-a8dc-8dbf859dec9a",
+              "Items": [
+                {
+                  "Id": "3510",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3cb273a2-7366-41e6-a9fd-5b233863c2ce",
+                    "FilterBase": [
+                      {
+                        "Id": "14058",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2adf4178-8025-477d-b54f-3de2ecfa3c14",
+                          "DataColumn": [
+                            {
+                              "Id": "14060",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "357",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14058",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3514",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c9e0a6f3-c9dc-461e-b5d0-c62199893f5d",
+                    "FilterBase": [
+                      {
+                        "Id": "14066",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8320d32d-2c5f-4bc4-a997-d7f2080dea76",
+                          "DataColumn": [
+                            {
+                              "Id": "14068",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "262",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "14069",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3518",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "af7ffc5a-cda2-406e-8e8c-391621e2be03",
+                    "FilterBase": [
+                      {
+                        "Id": "14071",
+                        "Type": "ItemFilter",
+                        "Fields": {
+                          "DocumentNodeId": "bb2572f2-5c28-40ef-9711-d0a5733460ec",
+                          "DataColumn": [
+                            {
+                              "Id": "14073",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "407",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "Value": [
+                            {
+                              "Id": "14074",
+                              "Type": "ItemFiltering",
+                              "Fields": {
+                                "value__": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "AllowAll": "true",
+                          "ShowNone": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3522",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ab44aaea-08a2-4df7-8d10-a829c8f0f1fe",
+                    "FilterBase": [
+                      {
+                        "Id": "14076",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "false",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "14077",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "e3954f65-a547-49db-8822-3b02d86e4294",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "a48ec083-47d0-4e2c-893d-5b472927788d",
+                          "DataColumn": [
+                            {
+                              "Id": "14080",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "114",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3526",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "04046e6d-05bb-4ae7-a4e9-53a2fed149bf",
+                    "FilterBase": [
+                      {
+                        "Id": "14082",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2fdf7c31-3175-4c10-8178-5af6c375b8d8",
+                          "DataColumn": [
+                            {
+                              "Id": "14084",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "173",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "14085",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3530",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9545ecfb-0279-45eb-8dd5-6bf8995c12cd",
+                    "FilterBase": [
+                      {
+                        "Id": "14088",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "84ae45fc-e00e-4970-939e-fbb5aaa48175",
+                          "DataColumn": [
+                            {
+                              "Id": "14090",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "505",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "14091",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3534",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "ed03fd0b-c752-485f-9f9b-ebde346f34b6",
+                    "FilterBase": [
+                      {
+                        "Id": "14094",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "b91afa3d-cf7e-4e5c-8f2c-df1904f1ea3e",
+                          "DataColumn": [
+                            {
+                              "Id": "14096",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "527",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14094",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3538",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1a7b9fc4-9d82-4c5e-a480-4fe60114c417",
+                    "FilterBase": [
+                      {
+                        "Id": "14102",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "164d8172-cfb9-4034-a11e-643d100c49bc",
+                          "DataColumn": [
+                            {
+                              "Id": "14104",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "545",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14102",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3542",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "48cdaf79-3a5d-4e6c-a2f2-82063642c656",
+                    "FilterBase": [
+                      {
+                        "Id": "14110",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "21cec021-61b5-4a44-b56e-ad56281dcdc6",
+                          "DataColumn": [
+                            {
+                              "Id": "14112",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "563",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14110",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3546",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3192385c-c993-4a77-a95e-db347d5999de",
+                    "FilterBase": [
+                      {
+                        "Id": "14118",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "36e4491c-7816-4ec8-b37d-af3729ba45aa",
+                          "DataColumn": [
+                            {
+                              "Id": "14120",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "581",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14118",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3550",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "9fc1ae8e-97ff-4d97-9686-82e2c8caa498",
+                    "FilterBase": [
+                      {
+                        "Id": "14126",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8581839e-c4e1-48b4-bc47-cfe9c40981c0",
+                          "DataColumn": [
+                            {
+                              "Id": "14128",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "599",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14126",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3554",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d218b930-9398-4709-b224-6a03c086481c",
+                    "FilterBase": [
+                      {
+                        "Id": "14134",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "014a7544-b2b4-4727-a476-2cc2b3b1b238",
+                          "DataColumn": [
+                            {
+                              "Id": "14136",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "617",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14134",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3558",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "21ffe7d9-d67f-43b3-9078-da86b46e7801",
+                    "FilterBase": [
+                      {
+                        "Id": "14142",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "1a5a73e3-02ab-4c3f-9d3d-ae3d5aaeddee",
+                          "DataColumn": [
+                            {
+                              "Id": "14144",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "635",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14142",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3562",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "39a50644-87f0-4057-b8e1-efe2efecd3e0",
+                    "FilterBase": [
+                      {
+                        "Id": "14150",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0ec1e16b-ed0f-42f5-a304-79d52b6313b6",
+                          "DataColumn": [
+                            {
+                              "Id": "14152",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "653",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14150",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3566",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a8f32c31-051d-4254-a09b-a3fe0cc31a22",
+                    "FilterBase": [
+                      {
+                        "Id": "14158",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f9b7ced8-4b41-44e6-9636-8c374cd51606",
+                          "DataColumn": [
+                            {
+                              "Id": "14160",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "671",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14158",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3570",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bcc98f36-d7d8-439c-8660-4d16f7812bb0",
+                    "FilterBase": [
+                      {
+                        "Id": "14166",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "a033cb69-45ab-4604-8777-18a05b63bde4",
+                          "DataColumn": [
+                            {
+                              "Id": "14168",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "689",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14166",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3574",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "31e24afe-1417-430a-8e80-57cf8f3811cd",
+                    "FilterBase": [
+                      {
+                        "Id": "14174",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "44e5bf47-75df-4e53-a20d-178ff63e2a4b",
+                          "DataColumn": [
+                            {
+                              "Id": "14176",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "707",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14174",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3578",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "fccf38db-b574-4461-8742-6f9150cbf33d",
+                    "FilterBase": [
+                      {
+                        "Id": "14182",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "49ea7d38-b942-4b53-89ca-04baa18b5df9",
+                          "DataColumn": [
+                            {
+                              "Id": "14184",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "158",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14182",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3582",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3f22ed99-d552-43fa-bee7-3b673dc115cb",
+                    "FilterBase": [
+                      {
+                        "Id": "14190",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "82d2e853-fdf0-4ef6-898d-be28954ef1b7",
+                          "DataColumn": [
+                            {
+                              "Id": "14192",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "742",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14190",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3586",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "10687a53-2b3c-410e-b578-4bea9371dd26",
+                    "FilterBase": [
+                      {
+                        "Id": "14198",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "821ee2a2-14e6-490f-b3c3-222714e3e3bc",
+                          "DataColumn": [
+                            {
+                              "Id": "14200",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "760",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14198",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3590",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5b2e364b-c33c-44ea-810d-16608944c494",
+                    "FilterBase": [
+                      {
+                        "Id": "14206",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "182d5357-cf15-497b-a2ca-f5c86dfc3588",
+                          "DataColumn": [
+                            {
+                              "Id": "14208",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "782",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14206",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3594",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "d026b832-714b-41e0-b024-afbba49d8f4a",
+                    "FilterBase": [
+                      {
+                        "Id": "14214",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "10819290-d06c-49ee-a8f9-67cbbcbed12a",
+                          "DataColumn": [
+                            {
+                              "Id": "14216",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "806",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14214",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3598",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "161f88df-9b2e-4889-bfcf-0cce4e86de56",
+                    "FilterBase": [
+                      {
+                        "Id": "14222",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "64e77484-3235-43a6-82b0-9c3245e0cee1",
+                          "DataColumn": [
+                            {
+                              "Id": "14224",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "828",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14222",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3602",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1dfb7500-a83f-44b2-84fd-ae3df1ce0925",
+                    "FilterBase": [
+                      {
+                        "Id": "14230",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8486ef1f-64f3-4379-b553-3c13fa503e57",
+                          "DataColumn": [
+                            {
+                              "Id": "14232",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "846",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14230",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3606",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a48457f8-8fa5-4234-8485-4030270c79c0",
+                    "FilterBase": [
+                      {
+                        "Id": "14238",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d0dc80cd-8666-4e7c-bb00-161a3a8c4878",
+                          "DataColumn": [
+                            {
+                              "Id": "14240",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "247",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "14241",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3610",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c22728b6-368f-4743-8a4c-8f8f6f3d1791",
+                    "FilterBase": [
+                      {
+                        "Id": "14244",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8d6e6c2a-d034-40fc-bd20-413cb23b67ae",
+                          "DataColumn": [
+                            {
+                              "Id": "14246",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "881",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "14247",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3614",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "947835a2-1e1d-465f-bf1e-fe6439bb8549",
+                    "FilterBase": [
+                      {
+                        "Id": "14250",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "43fde1c3-ec37-403c-93ce-13ea8a1c35db",
+                          "DataColumn": [
+                            {
+                              "Id": "14252",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "901",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "14253",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "302",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "f37a7a36-2bc0-4459-aaeb-5495d9530ee0",
+                    "DataTable": "90",
+                    "FilterCollection": "3615"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "90",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "14256",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "99a9c5b9-6fc3-44c9-b6ee-b3054c494fc4",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          },
+          {
+            "Id": "3850",
+            "Type": "FilterCollection",
+            "Fields": {
+              "DocumentNodeId": "c6eb1e62-65c7-446a-b0a9-d8a2336e576f",
+              "Items": [
+                {
+                  "Id": "3625",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "053f69e9-f4e8-4caf-8a92-735e241a4047",
+                    "FilterBase": [
+                      {
+                        "Id": "14262",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d4b6b8f3-6855-4cb5-8731-76083884203a",
+                          "DataColumn": [
+                            {
+                              "Id": "14264",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1129",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14262",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3629",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "22ef60fe-fa16-42b5-bf32-177f14e83e9e",
+                    "FilterBase": [
+                      {
+                        "Id": "14270",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "14271",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "42cac993-7d69-49cb-a680-b634117287f4",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "865d4488-d30a-468f-9541-315949203117",
+                          "DataColumn": [
+                            {
+                              "Id": "14274",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1143",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3633",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "902cf277-0a5a-4ba7-9237-b4341a254e76",
+                    "FilterBase": [
+                      {
+                        "Id": "14276",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "14277",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "2cc8426d-5d8d-4f6b-9240-5d4816e3795f",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "4326314e-14c9-49f6-a8c4-480b321a882f",
+                          "DataColumn": [
+                            {
+                              "Id": "14280",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1161",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3637",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "16d7b6dd-90e0-4007-bf20-a052d7ea73dc",
+                    "FilterBase": [
+                      {
+                        "Id": "14282",
+                        "Type": "CheckBoxFilter",
+                        "Fields": {
+                          "DocumentNodeId": "4f65c6d4-8701-41e4-b41c-09ad73057d78",
+                          "DataColumn": [
+                            {
+                              "Id": "14284",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1175",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "UncheckedValues": [
+                            {
+                              "Id": "14285",
+                              "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                              "Fields": {
+                                "Items": []
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "IncludeEmpty": "true"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3641",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e4a4a260-8584-4eb2-94e7-6c536c7bd984",
+                    "FilterBase": [
+                      {
+                        "Id": "14288",
+                        "Type": "ListBoxFilter",
+                        "Fields": {
+                          "IncludeEmpty": "true",
+                          "IncludeAllValues": "true",
+                          "SearchExpression": "918",
+                          "Height": "7",
+                          "SearchFieldVisible": "true",
+                          "MultiSelectMode": "false",
+                          "CheckBoxMode": "false",
+                          "SelectedValuesState": [
+                            {
+                              "Id": "14289",
+                              "Type": "ListBoxFilter+TableSelectedValuesState",
+                              "Fields": {
+                                "DocumentNodeId": "cbc7d78f-b956-49e6-acd9-3c531d0c6acf",
+                                "SelectedValueIndexes": "0",
+                                "FilterTableSelectionColumn": "0",
+                                "ProducerKey": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ShowAll": "true",
+                          "DocumentNodeId": "c45b433c-e7a4-4f54-a3de-34a8eb63841e",
+                          "DataColumn": [
+                            {
+                              "Id": "14292",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1189",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ]
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3645",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "64462b49-5609-4a77-b0ab-9b89dc838d99",
+                    "FilterBase": [
+                      {
+                        "Id": "14294",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "9f2a2b22-240a-4a89-86a8-e178a88b4b67",
+                          "DataColumn": [
+                            {
+                              "Id": "14296",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1203",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14294",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3649",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8a9ae372-dd0a-42e0-bece-de105ef97ea0",
+                    "FilterBase": [
+                      {
+                        "Id": "14302",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "186e88cb-856f-4799-ae6e-0db989a140fb",
+                          "DataColumn": [
+                            {
+                              "Id": "14304",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1217",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14302",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3653",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "bef589c4-6483-4630-aad5-56e2ade2616c",
+                    "FilterBase": [
+                      {
+                        "Id": "14310",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6b43ab16-04b6-42b9-a662-83a090e1ad32",
+                          "DataColumn": [
+                            {
+                              "Id": "14312",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1231",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14310",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3657",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4bac62e4-a1c2-449f-a835-0117c1ef1e7e",
+                    "FilterBase": [
+                      {
+                        "Id": "14318",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "321b2f6b-4325-4854-b9a4-8f0fa0a0ced9",
+                          "DataColumn": [
+                            {
+                              "Id": "14320",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1245",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14318",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3661",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a195edd4-8182-48c2-9a67-b9ca4c16d138",
+                    "FilterBase": [
+                      {
+                        "Id": "14326",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "15146236-692d-410c-b48c-f5bda472ad19",
+                          "DataColumn": [
+                            {
+                              "Id": "14328",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1259",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14326",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3665",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "aec68627-8940-4671-92af-d2051756165d",
+                    "FilterBase": [
+                      {
+                        "Id": "14334",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "03d3a1b8-1021-4d34-a1ba-8ff224dfb989",
+                          "DataColumn": [
+                            {
+                              "Id": "14336",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1273",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14334",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3669",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "50454653-d692-4452-af14-378ee6cacfa6",
+                    "FilterBase": [
+                      {
+                        "Id": "14342",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "049fb3ae-c80e-4d79-98fa-08d354fd17fd",
+                          "DataColumn": [
+                            {
+                              "Id": "14344",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1287",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14342",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3673",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "206e7fad-a08b-482a-b5e9-d804ca5cb69d",
+                    "FilterBase": [
+                      {
+                        "Id": "14350",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "69af47e2-5f92-40d2-8f1a-9ac5feed559c",
+                          "DataColumn": [
+                            {
+                              "Id": "14352",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1301",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14350",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3677",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "2664ea8e-3392-4303-b830-f114ff2698e7",
+                    "FilterBase": [
+                      {
+                        "Id": "14358",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c2e016d0-6f01-4302-be5e-e634592f8e90",
+                          "DataColumn": [
+                            {
+                              "Id": "14360",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1315",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14358",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3681",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8f725d48-991f-4d35-9974-85fd909bc1b8",
+                    "FilterBase": [
+                      {
+                        "Id": "14366",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "440ba7e4-eca4-446e-8925-51acd8e4e441",
+                          "DataColumn": [
+                            {
+                              "Id": "14368",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1329",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14366",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3685",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a8f1c4c5-cefd-4271-b0d9-992834122aac",
+                    "FilterBase": [
+                      {
+                        "Id": "14374",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "808771d8-44a9-40e3-8fbd-c6136a41c91a",
+                          "DataColumn": [
+                            {
+                              "Id": "14376",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1343",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14374",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3689",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "405d9709-010d-4ce4-95d9-087490e76fe7",
+                    "FilterBase": [
+                      {
+                        "Id": "14382",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "f04c59f2-53a0-490f-8c83-347e2fefbaa0",
+                          "DataColumn": [
+                            {
+                              "Id": "14384",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1357",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14382",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3693",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "68eaeec0-11b5-40fc-abe4-54cadc6ac1c2",
+                    "FilterBase": [
+                      {
+                        "Id": "14390",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "38baa1ca-2f21-44a9-b2ba-c900d3026d58",
+                          "DataColumn": [
+                            {
+                              "Id": "14392",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1371",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14390",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3697",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "22d4946e-449a-4fc5-88cf-4ea0992d0d43",
+                    "FilterBase": [
+                      {
+                        "Id": "14398",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2a3102af-4f34-4745-8b75-ea3425e41261",
+                          "DataColumn": [
+                            {
+                              "Id": "14400",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1385",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14398",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3701",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5e8ec6ac-dab6-4ffc-8c2c-8ea8e889d2a4",
+                    "FilterBase": [
+                      {
+                        "Id": "14406",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "dd27a835-d84a-4256-9527-15998eb703ae",
+                          "DataColumn": [
+                            {
+                              "Id": "14408",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1399",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14406",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3705",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f40cbdb6-2099-43e8-80ad-b5553cdeb3dc",
+                    "FilterBase": [
+                      {
+                        "Id": "14414",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "bdc20f35-cae8-4e34-ae51-d93286033048",
+                          "DataColumn": [
+                            {
+                              "Id": "14416",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1413",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14414",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3709",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6f76c711-3fc1-4ee2-8d99-c8a0d1362a8d",
+                    "FilterBase": [
+                      {
+                        "Id": "14422",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "27309569-9014-4446-8fb5-4dc43463492a",
+                          "DataColumn": [
+                            {
+                              "Id": "14424",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1427",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14422",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3713",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "75b5a442-d683-437e-9ec9-2bc85f294b5b",
+                    "FilterBase": [
+                      {
+                        "Id": "14430",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "6259329f-573f-4a88-9678-d3a215350d30",
+                          "DataColumn": [
+                            {
+                              "Id": "14432",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1441",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14430",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3717",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "86414c07-a968-420f-9362-2f4413fe748b",
+                    "FilterBase": [
+                      {
+                        "Id": "14438",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "448c16b7-229c-4d08-ba2c-f853011f0074",
+                          "DataColumn": [
+                            {
+                              "Id": "14440",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1455",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14438",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3721",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "cf4061d2-e479-450d-9ea0-18e64aab5740",
+                    "FilterBase": [
+                      {
+                        "Id": "14446",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "33c17ba6-fb60-43e3-a81d-dde1b0eef134",
+                          "DataColumn": [
+                            {
+                              "Id": "14448",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1469",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14446",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3725",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "377243e7-c2b7-40ab-bae1-725277d12501",
+                    "FilterBase": [
+                      {
+                        "Id": "14454",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3936e6f3-0624-4ba8-b297-09c073ce8461",
+                          "DataColumn": [
+                            {
+                              "Id": "14456",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1483",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14454",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3729",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a64f5132-1978-4eb4-b082-3c5e3ee51637",
+                    "FilterBase": [
+                      {
+                        "Id": "14462",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "855e3fe4-958b-49f3-bcf7-0c39768baa7f",
+                          "DataColumn": [
+                            {
+                              "Id": "14464",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1497",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14462",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3733",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7d151155-f2c6-4942-bfc4-3d25d8a8008f",
+                    "FilterBase": [
+                      {
+                        "Id": "14470",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "3b1fe645-c417-450f-9b5d-de357d500a14",
+                          "DataColumn": [
+                            {
+                              "Id": "14472",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1511",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14470",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3737",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6eabf36f-9891-44d9-b87a-b03e743880f9",
+                    "FilterBase": [
+                      {
+                        "Id": "14478",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "90d415a2-2c78-4e9f-b751-126048bb16ce",
+                          "DataColumn": [
+                            {
+                              "Id": "14480",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1525",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14478",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3741",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "28c20d2f-6d0e-467d-938b-4709449a8ae8",
+                    "FilterBase": [
+                      {
+                        "Id": "14486",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "88498ea5-c712-4eac-b806-462c2a25bfd9",
+                          "DataColumn": [
+                            {
+                              "Id": "14488",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1539",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14486",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3745",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "4b340ee3-2f16-405e-aa26-9b36d97a26c4",
+                    "FilterBase": [
+                      {
+                        "Id": "14494",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0f774b94-b448-4897-b468-05dd6b53a007",
+                          "DataColumn": [
+                            {
+                              "Id": "14496",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1553",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14494",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3749",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "fcae01c3-04f3-4e52-9077-c48305239ad9",
+                    "FilterBase": [
+                      {
+                        "Id": "14502",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "69f16d70-40d1-4e5b-8e3c-94cf351af19b",
+                          "DataColumn": [
+                            {
+                              "Id": "14504",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1567",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14502",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3753",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "26f95bb5-b912-4011-85fd-ff73ee38f9eb",
+                    "FilterBase": [
+                      {
+                        "Id": "14510",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "74d0ea1a-88b9-45f0-93e4-4d38caa47e8d",
+                          "DataColumn": [
+                            {
+                              "Id": "14512",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1581",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14510",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3757",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "5a0116ce-8e14-4e1f-bd06-1113f3337136",
+                    "FilterBase": [
+                      {
+                        "Id": "14518",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "996efac2-aac6-40d6-ba3c-5e6c3dd1ea13",
+                          "DataColumn": [
+                            {
+                              "Id": "14520",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1595",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14518",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3761",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3f123b78-ea1a-459f-a227-93c8c57508c2",
+                    "FilterBase": [
+                      {
+                        "Id": "14526",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0b3147da-a009-492d-8c72-754d0c7c5b7b",
+                          "DataColumn": [
+                            {
+                              "Id": "14528",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1609",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14526",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3765",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b33e5f51-e73a-40ff-b91e-f56b903350cb",
+                    "FilterBase": [
+                      {
+                        "Id": "14534",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "c06c5373-4f49-412f-a422-b47ca638037b",
+                          "DataColumn": [
+                            {
+                              "Id": "14536",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1623",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14534",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3769",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "8c35b5a3-727b-479d-bcca-4d8a9ba7fcec",
+                    "FilterBase": [
+                      {
+                        "Id": "14542",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "69d3029b-ae9e-4e2e-abdf-fe11b8036b71",
+                          "DataColumn": [
+                            {
+                              "Id": "14544",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1637",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14542",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3773",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "87c60eec-1e38-45fd-a196-12a3ae42ce33",
+                    "FilterBase": [
+                      {
+                        "Id": "14550",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "e9c14b48-a3cc-46dc-93e7-3bb1d8cd7533",
+                          "DataColumn": [
+                            {
+                              "Id": "14552",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1651",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14550",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3777",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "91304694-b2b7-4800-82f3-cac24f2dd7fc",
+                    "FilterBase": [
+                      {
+                        "Id": "14558",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "743b76fd-0c01-441d-b745-1935ec6ec12f",
+                          "DataColumn": [
+                            {
+                              "Id": "14560",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1665",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14558",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3781",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "c286e44e-fade-434b-bc27-68e6e5c599c9",
+                    "FilterBase": [
+                      {
+                        "Id": "14566",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "51e5e2ff-292d-43d0-8e62-caf28564a132",
+                          "DataColumn": [
+                            {
+                              "Id": "14568",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1679",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14566",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3785",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "7de71913-4645-492b-a86f-75f7007cd0ab",
+                    "FilterBase": [
+                      {
+                        "Id": "14574",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "be0a6823-f67b-4cb3-b4ce-07cc5a8133b8",
+                          "DataColumn": [
+                            {
+                              "Id": "14576",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1693",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14574",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3789",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "879faea8-55b2-445f-ab3f-5028e5167300",
+                    "FilterBase": [
+                      {
+                        "Id": "14582",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "cc911194-6b6f-4a66-827e-7be70f22bbca",
+                          "DataColumn": [
+                            {
+                              "Id": "14584",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1707",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14582",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3793",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "0dd9e74d-fc46-4ae9-b076-679d8be42aa4",
+                    "FilterBase": [
+                      {
+                        "Id": "14590",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "10c158c6-05b3-469f-87ad-727bc783a373",
+                          "DataColumn": [
+                            {
+                              "Id": "14592",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1721",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14590",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3797",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "b5892b5d-424f-4260-97c9-15e3ffc21229",
+                    "FilterBase": [
+                      {
+                        "Id": "14598",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "e5aae4b1-7140-4ff8-980f-35e97096bd54",
+                          "DataColumn": [
+                            {
+                              "Id": "14600",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1735",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14598",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3801",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "f97dee96-6658-433e-8320-0d2baf77d81d",
+                    "FilterBase": [
+                      {
+                        "Id": "14606",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0e47edca-9768-4826-93bc-13eaf14d82b2",
+                          "DataColumn": [
+                            {
+                              "Id": "14608",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1749",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14606",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3805",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "711845e8-48d3-48c0-9565-79461a03c6fa",
+                    "FilterBase": [
+                      {
+                        "Id": "14614",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0505a3ff-7997-4409-b46d-beede851d4e8",
+                          "DataColumn": [
+                            {
+                              "Id": "14616",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1763",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14614",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3809",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "772ffd8a-bc75-4246-bdc6-6822c9da4816",
+                    "FilterBase": [
+                      {
+                        "Id": "14622",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "dfc32db9-3f73-4fb5-8623-0d31d221a73a",
+                          "DataColumn": [
+                            {
+                              "Id": "14624",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1777",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14622",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3813",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "aa8a8fc6-d960-483f-b9cf-339abcc30417",
+                    "FilterBase": [
+                      {
+                        "Id": "14630",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "8ca907d5-178c-4bca-80cb-8d18be87fe89",
+                          "DataColumn": [
+                            {
+                              "Id": "14632",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1791",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14630",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3817",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "294daace-6c36-421a-8ff2-54b53a217df5",
+                    "FilterBase": [
+                      {
+                        "Id": "14638",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "ed4b4b7f-bf43-49fa-bc76-09e115f1dca9",
+                          "DataColumn": [
+                            {
+                              "Id": "14640",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1805",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14638",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3821",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "46ebf6e8-1dd2-4bb2-843a-6cfcdcd75d05",
+                    "FilterBase": [
+                      {
+                        "Id": "14646",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "d42ff6de-48b2-4731-9479-5703f5d33ca7",
+                          "DataColumn": [
+                            {
+                              "Id": "14648",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1819",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14646",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3825",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "e940d234-eba9-4434-98f1-9301706f1f62",
+                    "FilterBase": [
+                      {
+                        "Id": "14654",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "2221df89-f211-46bf-bbf7-4d022e3933ee",
+                          "DataColumn": [
+                            {
+                              "Id": "14656",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1833",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14654",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3829",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3801b43c-6a38-49e4-8bf1-b962ee952bdc",
+                    "FilterBase": [
+                      {
+                        "Id": "14662",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "39a3570c-0cbf-4330-b0b6-b5c51e9ab094",
+                          "DataColumn": [
+                            {
+                              "Id": "14664",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1847",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14662",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3833",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "1eca70ea-5438-42b5-add4-4eac7a1d886b",
+                    "FilterBase": [
+                      {
+                        "Id": "14670",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "fec303bd-4540-410a-b70c-53ff9e055b6b",
+                          "DataColumn": [
+                            {
+                              "Id": "14672",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1861",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14670",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3837",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "3025efd3-38d9-4f85-a12c-b6ef4b2fe34e",
+                    "FilterBase": [
+                      {
+                        "Id": "14678",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "79710877-a321-45a3-9d45-4326c22bbf7e",
+                          "DataColumn": [
+                            {
+                              "Id": "14680",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1875",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14678",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3841",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "6bdbc6f4-3405-4a68-bf56-59f6e53c2758",
+                    "FilterBase": [
+                      {
+                        "Id": "14686",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "fb6fc4d0-e0b0-4230-881a-10f431bc6b0b",
+                          "DataColumn": [
+                            {
+                              "Id": "14688",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1889",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14686",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3845",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "189c584f-8001-46d3-9380-48e106c34b20",
+                    "FilterBase": [
+                      {
+                        "Id": "14694",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "0ca916ac-ac20-425f-8948-e270d52b4636",
+                          "DataColumn": [
+                            {
+                              "Id": "14696",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1903",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14694",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                },
+                {
+                  "Id": "3849",
+                  "Type": "Filter",
+                  "Fields": {
+                    "DocumentNodeId": "a5095c8f-0beb-42ca-b068-c992bab3e499",
+                    "FilterBase": [
+                      {
+                        "Id": "14702",
+                        "Type": "RangeFilter",
+                        "Fields": {
+                          "DocumentNodeId": "87c7d894-4555-4e00-bd38-a644d6c903e6",
+                          "DataColumn": [
+                            {
+                              "Id": "14704",
+                              "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                              "Fields": {
+                                "Value": "1917",
+                                "ZombieHolder": "0"
+                              },
+                              "Children": []
+                            }
+                          ],
+                          "ValueRangeImpl": "",
+                          "ValueDataRangeImpl": "",
+                          "FilteredRowsDependsOnRowValues": "0",
+                          "FilterDependsOnMinAndMax": "14702",
+                          "FilterDependsOnDistinctKeys": "0",
+                          "IncludeEmpty": "true",
+                          "VisualScale": "Linear"
+                        },
+                        "Children": []
+                      }
+                    ]
+                  },
+                  "Children": []
+                }
+              ],
+              "SelectionProvider": [
+                {
+                  "Id": "306",
+                  "Type": "TableFilterSetSelectionProvider",
+                  "Fields": {
+                    "DocumentNodeId": "7c1191c6-336f-44ce-8398-4610270fce74",
+                    "DataTable": "305",
+                    "FilterCollection": "3850"
+                  },
+                  "Children": []
+                }
+              ],
+              "DataTable": "305",
+              "AutoCreateFilters": "true",
+              "AdditionalFilters": [
+                {
+                  "Id": "14710",
+                  "Type": "AdditionalFilterCollection",
+                  "Fields": {
+                    "DocumentNodeId": "a7b146f3-50f9-4e15-b08e-82354fcdbc4c",
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ],
+        "DataSelection": "295",
+        "AutoConfigureFilterCollections": "true"
+      },
+      "Children": []
+    },
+    {
+      "Id": "3510",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3cb273a2-7366-41e6-a9fd-5b233863c2ce",
+        "FilterBase": [
+          {
+            "Id": "14058",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2adf4178-8025-477d-b54f-3de2ecfa3c14",
+              "DataColumn": [
+                {
+                  "Id": "14060",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "357",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14058",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3514",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c9e0a6f3-c9dc-461e-b5d0-c62199893f5d",
+        "FilterBase": [
+          {
+            "Id": "14066",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "8320d32d-2c5f-4bc4-a997-d7f2080dea76",
+              "DataColumn": [
+                {
+                  "Id": "14068",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "262",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "14069",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3518",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "af7ffc5a-cda2-406e-8e8c-391621e2be03",
+        "FilterBase": [
+          {
+            "Id": "14071",
+            "Type": "ItemFilter",
+            "Fields": {
+              "DocumentNodeId": "bb2572f2-5c28-40ef-9711-d0a5733460ec",
+              "DataColumn": [
+                {
+                  "Id": "14073",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "407",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "Value": [
+                {
+                  "Id": "14074",
+                  "Type": "ItemFiltering",
+                  "Fields": {
+                    "value__": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "AllowAll": "true",
+              "ShowNone": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3522",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ab44aaea-08a2-4df7-8d10-a829c8f0f1fe",
+        "FilterBase": [
+          {
+            "Id": "14076",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "false",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "14077",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "e3954f65-a547-49db-8822-3b02d86e4294",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "a48ec083-47d0-4e2c-893d-5b472927788d",
+              "DataColumn": [
+                {
+                  "Id": "14080",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "114",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3526",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "04046e6d-05bb-4ae7-a4e9-53a2fed149bf",
+        "FilterBase": [
+          {
+            "Id": "14082",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "2fdf7c31-3175-4c10-8178-5af6c375b8d8",
+              "DataColumn": [
+                {
+                  "Id": "14084",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "173",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "14085",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3530",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9545ecfb-0279-45eb-8dd5-6bf8995c12cd",
+        "FilterBase": [
+          {
+            "Id": "14088",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "84ae45fc-e00e-4970-939e-fbb5aaa48175",
+              "DataColumn": [
+                {
+                  "Id": "14090",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "505",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "14091",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3534",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "ed03fd0b-c752-485f-9f9b-ebde346f34b6",
+        "FilterBase": [
+          {
+            "Id": "14094",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "b91afa3d-cf7e-4e5c-8f2c-df1904f1ea3e",
+              "DataColumn": [
+                {
+                  "Id": "14096",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "527",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14094",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3538",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1a7b9fc4-9d82-4c5e-a480-4fe60114c417",
+        "FilterBase": [
+          {
+            "Id": "14102",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "164d8172-cfb9-4034-a11e-643d100c49bc",
+              "DataColumn": [
+                {
+                  "Id": "14104",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "545",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14102",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3542",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "48cdaf79-3a5d-4e6c-a2f2-82063642c656",
+        "FilterBase": [
+          {
+            "Id": "14110",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "21cec021-61b5-4a44-b56e-ad56281dcdc6",
+              "DataColumn": [
+                {
+                  "Id": "14112",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "563",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14110",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3546",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3192385c-c993-4a77-a95e-db347d5999de",
+        "FilterBase": [
+          {
+            "Id": "14118",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "36e4491c-7816-4ec8-b37d-af3729ba45aa",
+              "DataColumn": [
+                {
+                  "Id": "14120",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "581",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14118",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3550",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "9fc1ae8e-97ff-4d97-9686-82e2c8caa498",
+        "FilterBase": [
+          {
+            "Id": "14126",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "8581839e-c4e1-48b4-bc47-cfe9c40981c0",
+              "DataColumn": [
+                {
+                  "Id": "14128",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "599",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14126",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3554",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d218b930-9398-4709-b224-6a03c086481c",
+        "FilterBase": [
+          {
+            "Id": "14134",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "014a7544-b2b4-4727-a476-2cc2b3b1b238",
+              "DataColumn": [
+                {
+                  "Id": "14136",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "617",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14134",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3558",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "21ffe7d9-d67f-43b3-9078-da86b46e7801",
+        "FilterBase": [
+          {
+            "Id": "14142",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "1a5a73e3-02ab-4c3f-9d3d-ae3d5aaeddee",
+              "DataColumn": [
+                {
+                  "Id": "14144",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "635",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14142",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3562",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "39a50644-87f0-4057-b8e1-efe2efecd3e0",
+        "FilterBase": [
+          {
+            "Id": "14150",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0ec1e16b-ed0f-42f5-a304-79d52b6313b6",
+              "DataColumn": [
+                {
+                  "Id": "14152",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "653",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14150",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3566",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a8f32c31-051d-4254-a09b-a3fe0cc31a22",
+        "FilterBase": [
+          {
+            "Id": "14158",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "f9b7ced8-4b41-44e6-9636-8c374cd51606",
+              "DataColumn": [
+                {
+                  "Id": "14160",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "671",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14158",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3570",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bcc98f36-d7d8-439c-8660-4d16f7812bb0",
+        "FilterBase": [
+          {
+            "Id": "14166",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "a033cb69-45ab-4604-8777-18a05b63bde4",
+              "DataColumn": [
+                {
+                  "Id": "14168",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "689",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14166",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3574",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "31e24afe-1417-430a-8e80-57cf8f3811cd",
+        "FilterBase": [
+          {
+            "Id": "14174",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "44e5bf47-75df-4e53-a20d-178ff63e2a4b",
+              "DataColumn": [
+                {
+                  "Id": "14176",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "707",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14174",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3578",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "fccf38db-b574-4461-8742-6f9150cbf33d",
+        "FilterBase": [
+          {
+            "Id": "14182",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "49ea7d38-b942-4b53-89ca-04baa18b5df9",
+              "DataColumn": [
+                {
+                  "Id": "14184",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "158",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14182",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3582",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3f22ed99-d552-43fa-bee7-3b673dc115cb",
+        "FilterBase": [
+          {
+            "Id": "14190",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "82d2e853-fdf0-4ef6-898d-be28954ef1b7",
+              "DataColumn": [
+                {
+                  "Id": "14192",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "742",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14190",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3586",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "10687a53-2b3c-410e-b578-4bea9371dd26",
+        "FilterBase": [
+          {
+            "Id": "14198",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "821ee2a2-14e6-490f-b3c3-222714e3e3bc",
+              "DataColumn": [
+                {
+                  "Id": "14200",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "760",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14198",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3590",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5b2e364b-c33c-44ea-810d-16608944c494",
+        "FilterBase": [
+          {
+            "Id": "14206",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "182d5357-cf15-497b-a2ca-f5c86dfc3588",
+              "DataColumn": [
+                {
+                  "Id": "14208",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "782",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14206",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3594",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "d026b832-714b-41e0-b024-afbba49d8f4a",
+        "FilterBase": [
+          {
+            "Id": "14214",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "10819290-d06c-49ee-a8f9-67cbbcbed12a",
+              "DataColumn": [
+                {
+                  "Id": "14216",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "806",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14214",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3598",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "161f88df-9b2e-4889-bfcf-0cce4e86de56",
+        "FilterBase": [
+          {
+            "Id": "14222",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "64e77484-3235-43a6-82b0-9c3245e0cee1",
+              "DataColumn": [
+                {
+                  "Id": "14224",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "828",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14222",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3602",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1dfb7500-a83f-44b2-84fd-ae3df1ce0925",
+        "FilterBase": [
+          {
+            "Id": "14230",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "8486ef1f-64f3-4379-b553-3c13fa503e57",
+              "DataColumn": [
+                {
+                  "Id": "14232",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "846",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14230",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3606",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a48457f8-8fa5-4234-8485-4030270c79c0",
+        "FilterBase": [
+          {
+            "Id": "14238",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "d0dc80cd-8666-4e7c-bb00-161a3a8c4878",
+              "DataColumn": [
+                {
+                  "Id": "14240",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "247",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "14241",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3610",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c22728b6-368f-4743-8a4c-8f8f6f3d1791",
+        "FilterBase": [
+          {
+            "Id": "14244",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "8d6e6c2a-d034-40fc-bd20-413cb23b67ae",
+              "DataColumn": [
+                {
+                  "Id": "14246",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "881",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "14247",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3614",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "947835a2-1e1d-465f-bf1e-fe6439bb8549",
+        "FilterBase": [
+          {
+            "Id": "14250",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "43fde1c3-ec37-403c-93ce-13ea8a1c35db",
+              "DataColumn": [
+                {
+                  "Id": "14252",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "901",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "14253",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3625",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "053f69e9-f4e8-4caf-8a92-735e241a4047",
+        "FilterBase": [
+          {
+            "Id": "14262",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d4b6b8f3-6855-4cb5-8731-76083884203a",
+              "DataColumn": [
+                {
+                  "Id": "14264",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1129",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14262",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3629",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "22ef60fe-fa16-42b5-bf32-177f14e83e9e",
+        "FilterBase": [
+          {
+            "Id": "14270",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "14271",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "42cac993-7d69-49cb-a680-b634117287f4",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "865d4488-d30a-468f-9541-315949203117",
+              "DataColumn": [
+                {
+                  "Id": "14274",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1143",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3633",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "902cf277-0a5a-4ba7-9237-b4341a254e76",
+        "FilterBase": [
+          {
+            "Id": "14276",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "14277",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "2cc8426d-5d8d-4f6b-9240-5d4816e3795f",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "4326314e-14c9-49f6-a8c4-480b321a882f",
+              "DataColumn": [
+                {
+                  "Id": "14280",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1161",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3637",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "16d7b6dd-90e0-4007-bf20-a052d7ea73dc",
+        "FilterBase": [
+          {
+            "Id": "14282",
+            "Type": "CheckBoxFilter",
+            "Fields": {
+              "DocumentNodeId": "4f65c6d4-8701-41e4-b41c-09ad73057d78",
+              "DataColumn": [
+                {
+                  "Id": "14284",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1175",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "UncheckedValues": [
+                {
+                  "Id": "14285",
+                  "Type": "0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]",
+                  "Fields": {
+                    "Items": []
+                  },
+                  "Children": []
+                }
+              ],
+              "IncludeEmpty": "true"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3641",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e4a4a260-8584-4eb2-94e7-6c536c7bd984",
+        "FilterBase": [
+          {
+            "Id": "14288",
+            "Type": "ListBoxFilter",
+            "Fields": {
+              "IncludeEmpty": "true",
+              "IncludeAllValues": "true",
+              "SearchExpression": "918",
+              "Height": "7",
+              "SearchFieldVisible": "true",
+              "MultiSelectMode": "false",
+              "CheckBoxMode": "false",
+              "SelectedValuesState": [
+                {
+                  "Id": "14289",
+                  "Type": "ListBoxFilter+TableSelectedValuesState",
+                  "Fields": {
+                    "DocumentNodeId": "cbc7d78f-b956-49e6-acd9-3c531d0c6acf",
+                    "SelectedValueIndexes": "0",
+                    "FilterTableSelectionColumn": "0",
+                    "ProducerKey": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ShowAll": "true",
+              "DocumentNodeId": "c45b433c-e7a4-4f54-a3de-34a8eb63841e",
+              "DataColumn": [
+                {
+                  "Id": "14292",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1189",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ]
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3645",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "64462b49-5609-4a77-b0ab-9b89dc838d99",
+        "FilterBase": [
+          {
+            "Id": "14294",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "9f2a2b22-240a-4a89-86a8-e178a88b4b67",
+              "DataColumn": [
+                {
+                  "Id": "14296",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1203",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14294",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3649",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8a9ae372-dd0a-42e0-bece-de105ef97ea0",
+        "FilterBase": [
+          {
+            "Id": "14302",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "186e88cb-856f-4799-ae6e-0db989a140fb",
+              "DataColumn": [
+                {
+                  "Id": "14304",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1217",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14302",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3653",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "bef589c4-6483-4630-aad5-56e2ade2616c",
+        "FilterBase": [
+          {
+            "Id": "14310",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6b43ab16-04b6-42b9-a662-83a090e1ad32",
+              "DataColumn": [
+                {
+                  "Id": "14312",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1231",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14310",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3657",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4bac62e4-a1c2-449f-a835-0117c1ef1e7e",
+        "FilterBase": [
+          {
+            "Id": "14318",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "321b2f6b-4325-4854-b9a4-8f0fa0a0ced9",
+              "DataColumn": [
+                {
+                  "Id": "14320",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1245",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14318",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3661",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a195edd4-8182-48c2-9a67-b9ca4c16d138",
+        "FilterBase": [
+          {
+            "Id": "14326",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "15146236-692d-410c-b48c-f5bda472ad19",
+              "DataColumn": [
+                {
+                  "Id": "14328",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1259",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14326",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3665",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "aec68627-8940-4671-92af-d2051756165d",
+        "FilterBase": [
+          {
+            "Id": "14334",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "03d3a1b8-1021-4d34-a1ba-8ff224dfb989",
+              "DataColumn": [
+                {
+                  "Id": "14336",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1273",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14334",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3669",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "50454653-d692-4452-af14-378ee6cacfa6",
+        "FilterBase": [
+          {
+            "Id": "14342",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "049fb3ae-c80e-4d79-98fa-08d354fd17fd",
+              "DataColumn": [
+                {
+                  "Id": "14344",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1287",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14342",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3673",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "206e7fad-a08b-482a-b5e9-d804ca5cb69d",
+        "FilterBase": [
+          {
+            "Id": "14350",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "69af47e2-5f92-40d2-8f1a-9ac5feed559c",
+              "DataColumn": [
+                {
+                  "Id": "14352",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1301",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14350",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3677",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "2664ea8e-3392-4303-b830-f114ff2698e7",
+        "FilterBase": [
+          {
+            "Id": "14358",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c2e016d0-6f01-4302-be5e-e634592f8e90",
+              "DataColumn": [
+                {
+                  "Id": "14360",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1315",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14358",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3681",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8f725d48-991f-4d35-9974-85fd909bc1b8",
+        "FilterBase": [
+          {
+            "Id": "14366",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "440ba7e4-eca4-446e-8925-51acd8e4e441",
+              "DataColumn": [
+                {
+                  "Id": "14368",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1329",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14366",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3685",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a8f1c4c5-cefd-4271-b0d9-992834122aac",
+        "FilterBase": [
+          {
+            "Id": "14374",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "808771d8-44a9-40e3-8fbd-c6136a41c91a",
+              "DataColumn": [
+                {
+                  "Id": "14376",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1343",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14374",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3689",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "405d9709-010d-4ce4-95d9-087490e76fe7",
+        "FilterBase": [
+          {
+            "Id": "14382",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "f04c59f2-53a0-490f-8c83-347e2fefbaa0",
+              "DataColumn": [
+                {
+                  "Id": "14384",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1357",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14382",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3693",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "68eaeec0-11b5-40fc-abe4-54cadc6ac1c2",
+        "FilterBase": [
+          {
+            "Id": "14390",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "38baa1ca-2f21-44a9-b2ba-c900d3026d58",
+              "DataColumn": [
+                {
+                  "Id": "14392",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1371",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14390",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3697",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "22d4946e-449a-4fc5-88cf-4ea0992d0d43",
+        "FilterBase": [
+          {
+            "Id": "14398",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2a3102af-4f34-4745-8b75-ea3425e41261",
+              "DataColumn": [
+                {
+                  "Id": "14400",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1385",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14398",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3701",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5e8ec6ac-dab6-4ffc-8c2c-8ea8e889d2a4",
+        "FilterBase": [
+          {
+            "Id": "14406",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "dd27a835-d84a-4256-9527-15998eb703ae",
+              "DataColumn": [
+                {
+                  "Id": "14408",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1399",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14406",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3705",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f40cbdb6-2099-43e8-80ad-b5553cdeb3dc",
+        "FilterBase": [
+          {
+            "Id": "14414",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "bdc20f35-cae8-4e34-ae51-d93286033048",
+              "DataColumn": [
+                {
+                  "Id": "14416",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1413",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14414",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3709",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6f76c711-3fc1-4ee2-8d99-c8a0d1362a8d",
+        "FilterBase": [
+          {
+            "Id": "14422",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "27309569-9014-4446-8fb5-4dc43463492a",
+              "DataColumn": [
+                {
+                  "Id": "14424",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1427",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14422",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3713",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "75b5a442-d683-437e-9ec9-2bc85f294b5b",
+        "FilterBase": [
+          {
+            "Id": "14430",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "6259329f-573f-4a88-9678-d3a215350d30",
+              "DataColumn": [
+                {
+                  "Id": "14432",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1441",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14430",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3717",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "86414c07-a968-420f-9362-2f4413fe748b",
+        "FilterBase": [
+          {
+            "Id": "14438",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "448c16b7-229c-4d08-ba2c-f853011f0074",
+              "DataColumn": [
+                {
+                  "Id": "14440",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1455",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14438",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3721",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "cf4061d2-e479-450d-9ea0-18e64aab5740",
+        "FilterBase": [
+          {
+            "Id": "14446",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "33c17ba6-fb60-43e3-a81d-dde1b0eef134",
+              "DataColumn": [
+                {
+                  "Id": "14448",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1469",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14446",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3725",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "377243e7-c2b7-40ab-bae1-725277d12501",
+        "FilterBase": [
+          {
+            "Id": "14454",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3936e6f3-0624-4ba8-b297-09c073ce8461",
+              "DataColumn": [
+                {
+                  "Id": "14456",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1483",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14454",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3729",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a64f5132-1978-4eb4-b082-3c5e3ee51637",
+        "FilterBase": [
+          {
+            "Id": "14462",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "855e3fe4-958b-49f3-bcf7-0c39768baa7f",
+              "DataColumn": [
+                {
+                  "Id": "14464",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1497",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14462",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3733",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7d151155-f2c6-4942-bfc4-3d25d8a8008f",
+        "FilterBase": [
+          {
+            "Id": "14470",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "3b1fe645-c417-450f-9b5d-de357d500a14",
+              "DataColumn": [
+                {
+                  "Id": "14472",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1511",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14470",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3737",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6eabf36f-9891-44d9-b87a-b03e743880f9",
+        "FilterBase": [
+          {
+            "Id": "14478",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "90d415a2-2c78-4e9f-b751-126048bb16ce",
+              "DataColumn": [
+                {
+                  "Id": "14480",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1525",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14478",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3741",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "28c20d2f-6d0e-467d-938b-4709449a8ae8",
+        "FilterBase": [
+          {
+            "Id": "14486",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "88498ea5-c712-4eac-b806-462c2a25bfd9",
+              "DataColumn": [
+                {
+                  "Id": "14488",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1539",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14486",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3745",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "4b340ee3-2f16-405e-aa26-9b36d97a26c4",
+        "FilterBase": [
+          {
+            "Id": "14494",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0f774b94-b448-4897-b468-05dd6b53a007",
+              "DataColumn": [
+                {
+                  "Id": "14496",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1553",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14494",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3749",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "fcae01c3-04f3-4e52-9077-c48305239ad9",
+        "FilterBase": [
+          {
+            "Id": "14502",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "69f16d70-40d1-4e5b-8e3c-94cf351af19b",
+              "DataColumn": [
+                {
+                  "Id": "14504",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1567",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14502",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3753",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "26f95bb5-b912-4011-85fd-ff73ee38f9eb",
+        "FilterBase": [
+          {
+            "Id": "14510",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "74d0ea1a-88b9-45f0-93e4-4d38caa47e8d",
+              "DataColumn": [
+                {
+                  "Id": "14512",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1581",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14510",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3757",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "5a0116ce-8e14-4e1f-bd06-1113f3337136",
+        "FilterBase": [
+          {
+            "Id": "14518",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "996efac2-aac6-40d6-ba3c-5e6c3dd1ea13",
+              "DataColumn": [
+                {
+                  "Id": "14520",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1595",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14518",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3761",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3f123b78-ea1a-459f-a227-93c8c57508c2",
+        "FilterBase": [
+          {
+            "Id": "14526",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0b3147da-a009-492d-8c72-754d0c7c5b7b",
+              "DataColumn": [
+                {
+                  "Id": "14528",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1609",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14526",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3765",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b33e5f51-e73a-40ff-b91e-f56b903350cb",
+        "FilterBase": [
+          {
+            "Id": "14534",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "c06c5373-4f49-412f-a422-b47ca638037b",
+              "DataColumn": [
+                {
+                  "Id": "14536",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1623",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14534",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3769",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "8c35b5a3-727b-479d-bcca-4d8a9ba7fcec",
+        "FilterBase": [
+          {
+            "Id": "14542",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "69d3029b-ae9e-4e2e-abdf-fe11b8036b71",
+              "DataColumn": [
+                {
+                  "Id": "14544",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1637",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14542",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3773",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "87c60eec-1e38-45fd-a196-12a3ae42ce33",
+        "FilterBase": [
+          {
+            "Id": "14550",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "e9c14b48-a3cc-46dc-93e7-3bb1d8cd7533",
+              "DataColumn": [
+                {
+                  "Id": "14552",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1651",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14550",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3777",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "91304694-b2b7-4800-82f3-cac24f2dd7fc",
+        "FilterBase": [
+          {
+            "Id": "14558",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "743b76fd-0c01-441d-b745-1935ec6ec12f",
+              "DataColumn": [
+                {
+                  "Id": "14560",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1665",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14558",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3781",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "c286e44e-fade-434b-bc27-68e6e5c599c9",
+        "FilterBase": [
+          {
+            "Id": "14566",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "51e5e2ff-292d-43d0-8e62-caf28564a132",
+              "DataColumn": [
+                {
+                  "Id": "14568",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1679",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14566",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3785",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "7de71913-4645-492b-a86f-75f7007cd0ab",
+        "FilterBase": [
+          {
+            "Id": "14574",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "be0a6823-f67b-4cb3-b4ce-07cc5a8133b8",
+              "DataColumn": [
+                {
+                  "Id": "14576",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1693",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14574",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3789",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "879faea8-55b2-445f-ab3f-5028e5167300",
+        "FilterBase": [
+          {
+            "Id": "14582",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "cc911194-6b6f-4a66-827e-7be70f22bbca",
+              "DataColumn": [
+                {
+                  "Id": "14584",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1707",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14582",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3793",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "0dd9e74d-fc46-4ae9-b076-679d8be42aa4",
+        "FilterBase": [
+          {
+            "Id": "14590",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "10c158c6-05b3-469f-87ad-727bc783a373",
+              "DataColumn": [
+                {
+                  "Id": "14592",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1721",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14590",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3797",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "b5892b5d-424f-4260-97c9-15e3ffc21229",
+        "FilterBase": [
+          {
+            "Id": "14598",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "e5aae4b1-7140-4ff8-980f-35e97096bd54",
+              "DataColumn": [
+                {
+                  "Id": "14600",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1735",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14598",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3801",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "f97dee96-6658-433e-8320-0d2baf77d81d",
+        "FilterBase": [
+          {
+            "Id": "14606",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0e47edca-9768-4826-93bc-13eaf14d82b2",
+              "DataColumn": [
+                {
+                  "Id": "14608",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1749",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14606",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3805",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "711845e8-48d3-48c0-9565-79461a03c6fa",
+        "FilterBase": [
+          {
+            "Id": "14614",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0505a3ff-7997-4409-b46d-beede851d4e8",
+              "DataColumn": [
+                {
+                  "Id": "14616",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1763",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14614",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3809",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "772ffd8a-bc75-4246-bdc6-6822c9da4816",
+        "FilterBase": [
+          {
+            "Id": "14622",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "dfc32db9-3f73-4fb5-8623-0d31d221a73a",
+              "DataColumn": [
+                {
+                  "Id": "14624",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1777",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14622",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3813",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "aa8a8fc6-d960-483f-b9cf-339abcc30417",
+        "FilterBase": [
+          {
+            "Id": "14630",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "8ca907d5-178c-4bca-80cb-8d18be87fe89",
+              "DataColumn": [
+                {
+                  "Id": "14632",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1791",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14630",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3817",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "294daace-6c36-421a-8ff2-54b53a217df5",
+        "FilterBase": [
+          {
+            "Id": "14638",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "ed4b4b7f-bf43-49fa-bc76-09e115f1dca9",
+              "DataColumn": [
+                {
+                  "Id": "14640",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1805",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14638",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3821",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "46ebf6e8-1dd2-4bb2-843a-6cfcdcd75d05",
+        "FilterBase": [
+          {
+            "Id": "14646",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "d42ff6de-48b2-4731-9479-5703f5d33ca7",
+              "DataColumn": [
+                {
+                  "Id": "14648",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1819",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14646",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3825",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "e940d234-eba9-4434-98f1-9301706f1f62",
+        "FilterBase": [
+          {
+            "Id": "14654",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "2221df89-f211-46bf-bbf7-4d022e3933ee",
+              "DataColumn": [
+                {
+                  "Id": "14656",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1833",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14654",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3829",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3801b43c-6a38-49e4-8bf1-b962ee952bdc",
+        "FilterBase": [
+          {
+            "Id": "14662",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "39a3570c-0cbf-4330-b0b6-b5c51e9ab094",
+              "DataColumn": [
+                {
+                  "Id": "14664",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1847",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14662",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3833",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "1eca70ea-5438-42b5-add4-4eac7a1d886b",
+        "FilterBase": [
+          {
+            "Id": "14670",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "fec303bd-4540-410a-b70c-53ff9e055b6b",
+              "DataColumn": [
+                {
+                  "Id": "14672",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1861",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14670",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3837",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "3025efd3-38d9-4f85-a12c-b6ef4b2fe34e",
+        "FilterBase": [
+          {
+            "Id": "14678",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "79710877-a321-45a3-9d45-4326c22bbf7e",
+              "DataColumn": [
+                {
+                  "Id": "14680",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1875",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14678",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3841",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "6bdbc6f4-3405-4a68-bf56-59f6e53c2758",
+        "FilterBase": [
+          {
+            "Id": "14686",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "fb6fc4d0-e0b0-4230-881a-10f431bc6b0b",
+              "DataColumn": [
+                {
+                  "Id": "14688",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1889",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14686",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3845",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "189c584f-8001-46d3-9380-48e106c34b20",
+        "FilterBase": [
+          {
+            "Id": "14694",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "0ca916ac-ac20-425f-8948-e270d52b4636",
+              "DataColumn": [
+                {
+                  "Id": "14696",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1903",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14694",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    },
+    {
+      "Id": "3849",
+      "Type": "Filter",
+      "Fields": {
+        "DocumentNodeId": "a5095c8f-0beb-42ca-b068-c992bab3e499",
+        "FilterBase": [
+          {
+            "Id": "14702",
+            "Type": "RangeFilter",
+            "Fields": {
+              "DocumentNodeId": "87c7d894-4555-4e00-bd38-a644d6c903e6",
+              "DataColumn": [
+                {
+                  "Id": "14704",
+                  "Type": "3646, Culture=neutral, PublicKeyToken=789861576bd64dc5]]",
+                  "Fields": {
+                    "Value": "1917",
+                    "ZombieHolder": "0"
+                  },
+                  "Children": []
+                }
+              ],
+              "ValueRangeImpl": "",
+              "ValueDataRangeImpl": "",
+              "FilteredRowsDependsOnRowValues": "0",
+              "FilterDependsOnMinAndMax": "14702",
+              "FilterDependsOnDistinctKeys": "0",
+              "IncludeEmpty": "true",
+              "VisualScale": "Linear"
+            },
+            "Children": []
+          }
+        ]
+      },
+      "Children": []
+    }
+  ],
   "Bookmarks": [],
   "Scripts": []
 }


### PR DESCRIPTION
## Summary
- handle Array elements when extracting field values
- resolve ObjectRef values via lookup tables
- decode DataTable column collections and populate metadata

## Testing
- `python3 parse_spotfire.py >/tmp/run.log && tail -n 20 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_68435d5ba5c88324b5dd80e7c2a9138a